### PR TITLE
Update README.md: browser example code typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,7 +1584,7 @@ const ref = await db.ref('browser').set({
 console.log(`"${ref.path}" was saved!`);
 
 const snapshot = await ref.get();
-console.log(`Got "${snapshot.ref.path}" value:`, snap.val());
+console.log(`Got "${snapshot.ref.path}" value:`, snapshot.val());
 ```
 
 Or, if you prefer using `Promises` instead of `async` / `await`:


### PR DESCRIPTION
Previously the example code would cause an error due to `snap` (undefined) being referenced instead of `snapshot`.

Considered changing it away from 'const' since it's likely there'll be someone (like me) that wants to interact with _other_ snapshots while playing around with examples 😄 