### PR TITLE
BigInt cache serialisation error

### DIFF
--- a/spec/query.spec.js
+++ b/spec/query.spec.js
@@ -406,7 +406,7 @@ fdescribe('Query index bigint', () => {
         const collection = ObjectCollection.from(movies);
 
         // Create collection
-        ref=db.ref('movies');
+        ref = db.ref('movies');
         await ref.set(collection);
 
         // Create indexes
@@ -423,7 +423,6 @@ fdescribe('Query index bigint', () => {
         const totalResults = await query.take(1000000).count();
 
         const results = snaps.getValues();
-
         expect(results).toEqual(movies);
         expect(totalResults).toEqual(2);
     }, 60 * 60 * 1000);

--- a/spec/query.spec.js
+++ b/spec/query.spec.js
@@ -366,6 +366,69 @@ describe('Query with take/sort/indexes #124', () => {
     }, 60 * 60 * 1000);
 });
 
+fdescribe('Query index bigint', () => {
+    /** @type {AceBase} */
+    let db;
+    let ref;
+    /** @type {{(): Promise<void>}} */
+    let removeDB;
+    /** @type Array<{ id: string; title: string; year: number }> */
+    let movies;
+
+    afterAll(async () => {
+        await removeDB();
+    });
+
+    beforeAll(async () => {
+        ({ db, removeDB } = await createTempDB());
+
+        movies = [{
+            id: 'tt0111161',
+            title: 'The Shawshank Redemption',
+            year: 1994,
+            description: 'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.',
+            genres: ['crime', 'drama'],
+            rating: 9.3,
+            votes: 1951324,
+            popularity: 114,
+            aBigIntValue: BigInt(114),
+        }, {
+            id: 'tt0068646',
+            title: 'The Godfather',
+            year: 1972,
+            description: 'The aging patriarch of an organized crime dynasty transfers control of his clandestine empire to his reluctant son.',
+            genres: ['crime', 'drama'],
+            rating: 9.2,
+            votes: 1335641,
+            popularity: 123,
+            aBigIntValue: BigInt(123),
+        }];
+        const collection = ObjectCollection.from(movies);
+
+        // Create collection
+        ref=db.ref('movies');
+        await ref.set(collection);
+
+        // Create indexes
+        await db.indexes.create('movies', 'aBigIntValue');
+    });
+
+    it('test', async () => {
+        // Query movies: filter by title, order by year (desc), take 10
+        const query = ref.query();
+        query.filter('aBigIntValue', '>', BigInt(1));
+        query.sort('year', false);
+
+        const snaps = await query.get();
+        const totalResults = await query.take(1000000).count();
+
+        const results = snaps.getValues();
+
+        expect(results).toEqual(movies);
+        expect(totalResults).toEqual(2);
+    }, 60 * 60 * 1000);
+});
+
 describe('Wildcard query', () => {
     /** @type {AceBase} */
     let db;

--- a/src/data-index/index.js
+++ b/src/data-index/index.js
@@ -173,8 +173,7 @@ class DataIndex {
         };
     }
     cache(op, param, results) {
-        console.log("Error is here, BigInt can't be serailized", param)
-        const val = JSON.stringify(param); // Make object and array params cachable too
+        const val = JSON.stringify(param, (_, v) => typeof v === 'bigint' ? v.toString() : v);
         if (typeof results === 'undefined') {
             // Get from cache
             let cache;

--- a/src/data-index/index.js
+++ b/src/data-index/index.js
@@ -173,6 +173,7 @@ class DataIndex {
         };
     }
     cache(op, param, results) {
+        console.log("Error is here, BigInt can't be serailized", param)
         const val = JSON.stringify(param); // Make object and array params cachable too
         if (typeof results === 'undefined') {
             // Get from cache

--- a/src/ts/data-index/index.ts
+++ b/src/ts/data-index/index.ts
@@ -289,8 +289,7 @@ export class DataIndex {
     }
 
     cache(op: string, param: unknown, results?: any) {
-        console.log("Error is here, BigInt can't be serailized", param)
-        const val = JSON.stringify(param); // Make object and array params cachable too
+        const val = JSON.stringify(param, (_, v) => typeof v === 'bigint' ? v.toString() : v);
         if (typeof results === 'undefined') {
             // Get from cache
             let cache;

--- a/src/ts/data-index/index.ts
+++ b/src/ts/data-index/index.ts
@@ -289,6 +289,7 @@ export class DataIndex {
     }
 
     cache(op: string, param: unknown, results?: any) {
+        console.log("Error is here, BigInt can't be serailized", param)
         const val = JSON.stringify(param); // Make object and array params cachable too
         if (typeof results === 'undefined') {
             // Get from cache


### PR DESCRIPTION
Hi :)
When filtering on an indexed BigInt value, it throws an error as a big int as no default way to be serialized.
The proposed solution work on serialisation but it does not work at all querying results.
Hope it can help you :)
Thank you !