### PR TITLE
fix: include sources & maps in npm distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,10 @@
 # Exclude dev files from npm package
-src/ts
-src/**/*.js.map
-src/**/*.d.ts
-spec
-.eslintrc*.*
-tsconfig*.*
+# src/ts
+# src/**/*.js.map
+# src/**/*.d.ts
+# spec
+# .eslintrc*.*
+# tsconfig*.*
 img
 .github
 .vscode


### PR DESCRIPTION
Temporarily allow sources and source maps to be included in npm distributions, fixes missing types