### PR TITLE
Fix broken B+Trees

### DIFF
--- a/src/api-local.ts
+++ b/src/api-local.ts
@@ -12,6 +12,7 @@ import { Storage, StorageEnv } from './storage';
 import { CreateIndexOptions } from './storage/indexes';
 import type { BinaryNodeAddress } from './storage/binary/node-address';
 import { AceBaseLocalSettings } from '.';
+import { NodeNotFoundError } from './node-errors';
 
 export class LocalApi extends Api {
     // All api methods for local database instance
@@ -264,6 +265,9 @@ export class LocalApi extends Api {
                 })
                 .catch(err => {
                     // Node doesn't exist? No children..
+                    if (!(err instanceof NodeNotFoundError)) {
+                        throw err;
+                    }
                 });
             return {
                 more,

--- a/src/btree/binary-tree-builder.ts
+++ b/src/btree/binary-tree-builder.ts
@@ -2,11 +2,9 @@ import { Uint8ArrayBuilder, writeByteLength, writeSignedOffset } from '../binary
 import { DetailedError } from '../detailed-error';
 import { MAX_SMALL_LEAF_VALUE_LENGTH, WRITE_SMALL_LEAFS } from './config';
 import { BPlusTree } from './tree';
-import { BPlusTreeLeaf } from './tree-leaf';
 import { BPlusTreeLeafEntryValue } from './tree-leaf-entry-value';
 import { BinaryBPlusTreeLeafEntry } from './binary-tree-leaf-entry';
 import { Utils } from 'acebase-core';
-import { BPlusTreeLeafEntry } from './tree-leaf-entry';
 import { LeafEntryRecordPointer } from './leaf-entry-recordpointer';
 import { LeafEntryMetaData } from './leaf-entry-metadata';
 import { NodeEntryKeyType } from './entry-key-type';
@@ -178,12 +176,6 @@ export class BinaryBPlusTreeBuilder {
         return bytes;
     }
 
-    /**
-     *
-     * @param {} info
-     * @param {} options
-     * @returns {Uint8Array} bytes
-     */
     createLeaf(info: CreateLeafInfo, options: CreateLeafOptions = { addFreeSpace: true }) {
 
         // console.log(`Creating leaf for entries "${info.entries[0].key}" to "${info.entries.slice(-1)[0].key}" (${info.entries.length} entries, ${info.entries.reduce((total, entry) => total + entry.values.length, 0)} values)`);

--- a/src/btree/binary-tree-leaf.ts
+++ b/src/btree/binary-tree-leaf.ts
@@ -50,7 +50,7 @@ export class BinaryBPlusTreeLeaf extends BinaryBPlusTreeNodeInfo {
     /**
       * only present if there is a next leaf. Make sure to use ONLY while the tree is locked
       */
-    getNext?: () => Promise<BinaryBPlusTreeLeaf>;
+    getNext?: (repairMode?: boolean) => Promise<BinaryBPlusTreeLeaf>;
 
     get hasPrevious() { return typeof this.getPrevious === 'function'; }
     get hasNext() { return typeof this.getNext === 'function'; }

--- a/src/btree/binary-tree.spec.ts
+++ b/src/btree/binary-tree.spec.ts
@@ -1,18 +1,18 @@
 import { BPlusTree, BinaryWriter, BinaryBPlusTree, BlacklistingSearchOperator, BinaryBPlusTreeLeafEntry } from '.';
-import { ID } from 'acebase-core';
+import { DebugLogger, ID } from 'acebase-core';
 import { BinaryBPlusTreeLeafEntryValue } from './binary-tree-leaf-entry-value';
 
 describe('Unique Binary B+Tree', () => {
     // Tests basic operations of the BinaryBPlusTree implementation
     const FILL_FACTOR = 95; // AceBase uses 95% fill factor for key indexes
     const AUTO_GROW = false; // autoGrow is not used by AceBase atm
-
+    const debug = new DebugLogger('log', 'B+Tree');
     const createBinaryTree = async () => {
         const tree = new BPlusTree(100, true);
 
         const bytes = [] as number[];
         await tree.toBinary(true, BinaryWriter.forArray(bytes));
-        const binaryTree = new BinaryBPlusTree(bytes);
+        const binaryTree = new BinaryBPlusTree({ readFn: bytes, debug });
         binaryTree.id = ID.generate(); // Assign an id to allow edits (is enforced by tree to make sure multiple concurrent edits to the same source are sync locked)
         binaryTree.autoGrow = AUTO_GROW;
         return binaryTree;
@@ -22,7 +22,7 @@ describe('Unique Binary B+Tree', () => {
         const bytes = [] as number[];
         const id = tree.id;
         await tree.rebuild(BinaryWriter.forArray(bytes), { fillFactor: FILL_FACTOR, keepFreeSpace: true, increaseMaxEntries: true });
-        tree = new BinaryBPlusTree(bytes);
+        tree = new BinaryBPlusTree({ readFn: bytes, debug });
         tree.id = id;
         tree.autoGrow = AUTO_GROW;
         return tree;

--- a/src/btree/binary-tree.ts
+++ b/src/btree/binary-tree.ts
@@ -1916,7 +1916,7 @@ export class BinaryBPlusTree {
         if (!this._fst) { this._fst = []; }
         const available = this._fst.filter(block => block.length >= bytesRequired);
         if (available.length > 0) {
-            const best = available.sort((a, b) => a.length < b.length ? -1 : 1)[0];
+            const best = available.sort((a, b) => a.length - b.length)[0];
             this._fst.splice(this._fst.indexOf(best), 1);
             return best;
         }

--- a/src/btree/binary-tree.ts
+++ b/src/btree/binary-tree.ts
@@ -184,7 +184,7 @@ export class BinaryBPlusTree {
     set autoGrow(grow: boolean) {
         this._autoGrow = grow === true;
         // if (this._autoGrow) {
-        //     console.warn('autoGrow enabled for binary tree');
+        //     this.debug.warn('autoGrow enabled for binary tree');
         // }
     }
 
@@ -217,7 +217,7 @@ export class BinaryBPlusTree {
             metadataKeys: [],
         };
         // if (!this.info.hasLargePtrs) {
-        //     console.warn(`Warning: tree "${this.id}" is read-only because it contains small ptrs. it needs to be rebuilt`);
+        //     this.debug.warn(`Warning: tree "${this.id}" is read-only because it contains small ptrs. it needs to be rebuilt`);
         // }
         let additionalHeaderBytes = 0;
         if (this.info.hasFillFactor) { additionalHeaderBytes += 1; }
@@ -586,7 +586,7 @@ export class BinaryBPlusTree {
 
                                     // const oldLeafExtFreeBytes = leaf.extData.freeBytes;
                                     leaf.extData.freeBytes -= requiredSpace.bytes; // leaf.extData.length - (newOffset + requiredSpace.length);
-                                    // console.log(`addValue :: moving ext_block from index ${oldIndex} to ${entry.extData.index}, leaf's ext_data_free_bytes reduces from ${oldLeafExtFreeBytes} to ${leaf.extData.freeBytes} bytes`)
+                                    // this.debug.log(`addValue :: moving ext_block from index ${oldIndex} to ${entry.extData.index}, leaf's ext_data_free_bytes reduces from ${oldLeafExtFreeBytes} to ${leaf.extData.freeBytes} bytes`)
                                     extBlockMoves = true;
                                 }
                             }
@@ -631,8 +631,8 @@ export class BinaryBPlusTree {
                             // const displayIndex = index => (index + 4096).toString(16).toUpperCase();
                             // const displayBytes = bytes => '[' + bytes.map(b => b.toString(16)).join(',').toUpperCase() + ']';
                             try {
-                                // console.log(`TreeWrite:ext_block_length(${entry.extData.length}), ext_block_free_length(${entry.extData.freeBytes})${extBlockMoves ? ', value_list' : ''} :: ${extDataBlock.length} bytes at index ${displayIndex(self.index)}: ${displayBytes(extDataBlock.slice(0,4))}, ${displayBytes(extDataBlock.slice(4,8))}${extBlockMoves ? ', [...]' : ''}`);
-                                // console.log(`TreeWrite:value_list_length(${self.totalValues + 1}) :: ${valueListLengthData.length} bytes at index ${displayIndex(self._listLengthIndex)}: ${displayBytes(valueListLengthData)}`);
+                                // this.debug.log(`TreeWrite:ext_block_length(${entry.extData.length}), ext_block_free_length(${entry.extData.freeBytes})${extBlockMoves ? ', value_list' : ''} :: ${extDataBlock.length} bytes at index ${displayIndex(self.index)}: ${displayBytes(extDataBlock.slice(0,4))}, ${displayBytes(extDataBlock.slice(4,8))}${extBlockMoves ? ', [...]' : ''}`);
+                                // this.debug.log(`TreeWrite:value_list_length(${self.totalValues + 1}) :: ${valueListLengthData.length} bytes at index ${displayIndex(self._listLengthIndex)}: ${displayBytes(valueListLengthData)}`);
                                 const promises = [
                                     // Write header (ext_block_length, ext_block_free_length) or entire ext_data_block to its index:
                                     tree._writeFn(extDataBlock, self.index),
@@ -644,7 +644,7 @@ export class BinaryBPlusTree {
                                     // Write new ext_data_ptr in leaf entry's val_data
                                     let writeBytes = [0,0,0,0];
                                     writeByteLength(writeBytes, 0, extDataOffset);
-                                    // console.log(`TreeWrite:ext_data_ptr(${extDataOffset}) :: ${writeBytes.length} bytes at index ${displayIndex(self._listLengthIndex + 4)}: ${displayBytes(writeBytes)}`);
+                                    // this.debug.log(`TreeWrite:ext_data_ptr(${extDataOffset}) :: ${writeBytes.length} bytes at index ${displayIndex(self._listLengthIndex + 4)}: ${displayBytes(writeBytes)}`);
                                     let p = tree._writeFn(writeBytes, self._listLengthIndex + 4);
                                     promises.push(p);
 
@@ -655,13 +655,13 @@ export class BinaryBPlusTree {
                                         + 4; // ext_byte_length
                                     writeBytes = [0,0,0,0];
                                     writeByteLength(writeBytes, 0, leaf.extData.freeBytes);
-                                    // console.log(`TreeWrite:ext_free_byte_length(${leaf.extData.freeBytes}) :: ${writeBytes.length} bytes at index ${displayIndex(leafExtFreeBytesIndex)}: ${displayBytes(writeBytes)}`);
+                                    // this.debug.log(`TreeWrite:ext_free_byte_length(${leaf.extData.freeBytes}) :: ${writeBytes.length} bytes at index ${displayIndex(leafExtFreeBytesIndex)}: ${displayBytes(writeBytes)}`);
                                     p = tree._writeFn(writeBytes, leafExtFreeBytesIndex);
                                     promises.push(p);
                                 }
                                 else {
                                     // write new value:
-                                    // console.log(`TreeWrite:value :: ${extValueData.length} bytes at index ${displayIndex(newValueIndex)}: ${displayBytes(extValueData)}`);
+                                    // this.debug.log(`TreeWrite:value :: ${extValueData.length} bytes at index ${displayIndex(newValueIndex)}: ${displayBytes(extValueData)}`);
                                     const p = tree._writeFn(extValueData, newValueIndex);
                                     promises.push(p);
                                 }
@@ -671,12 +671,12 @@ export class BinaryBPlusTree {
 
                                 // TEST
                                 // try {
-                                //     console.log(`Values for entry '${entry.key}' updated: ${self.totalValues} values`);
+                                //     this.debug.log(`Values for entry '${entry.key}' updated: ${self.totalValues} values`);
                                 //     await tree._testTree();
-                                //     console.log(`Successfully added value to entry '${entry.key}'`);
+                                //     this.debug.log(`Successfully added value to entry '${entry.key}'`);
                                 // }
                                 // catch (err) {
-                                //     console.error(`Tree is broken after updating entry '${entry.key}': ${err.message}`);
+                                //     this.debug.error(`Tree is broken after updating entry '${entry.key}': ${err.message}`);
                                 // }
                             }
                             finally {
@@ -688,7 +688,7 @@ export class BinaryBPlusTree {
                             //     await self.loadValues();
                             // }
                             // catch (err) {
-                            //     console.error(`Values are broken after updating entry '${entry.key}': ${err.message}`);
+                            //     this.debug.error(`Values are broken after updating entry '${entry.key}': ${err.message}`);
                             // }
                         },
 
@@ -1402,7 +1402,7 @@ export class BinaryBPlusTree {
         // const t1 = Date.now();
         // const ret = () => {
         //     const t2 = Date.now();
-        //     console.log(`tree.search [${op} ${param}] took ${t2-t1}ms, matched ${totalMatches} values, returning ${totalAdded} values in ${results.entries.length} entries`);
+        //     this.debug.log(`tree.search [${op} ${param}] took ${t2-t1}ms, matched ${totalMatches} values, returning ${totalAdded} values in ${results.entries.length} entries`);
         //     return results;
         // };
         const ret = () => {
@@ -1878,12 +1878,12 @@ export class BinaryBPlusTree {
         if (!this._fst) { this._fst = []; }
         if (index + length === this.info.byteLength - this.info.freeSpace) {
             // Cancel free space allocated at the end of the file
-            // console.log(`Freeing ${length} bytes from index ${index} (at end of file)`);
+            // this.debug.log(`Freeing ${length} bytes from index ${index} (at end of file)`);
             this.info.freeSpace += length;
             await this._writeFn(writeByteLength([], 0, this.info.freeSpace), this.info.freeSpaceIndex); // free_byte_length
         }
         else {
-            // console.log(`Freeing ${length} bytes from index ${index} to ${index+length}`);
+            // this.debug.log(`Freeing ${length} bytes from index ${index} to ${index+length}`);
             this._fst.push({ index, length });
 
             // Normalize fst by joining adjacent blocks
@@ -2064,7 +2064,7 @@ export class BinaryBPlusTree {
 
             const freedBytes = leaf.length + leaf.extData.length;
 
-            // console.log(`Rebuilding leaf for entries "${leaf.entries[0].key}" to "${leaf.entries[leaf.entries.length-1].key}"`);
+            // this.debug.log(`Rebuilding leaf for entries "${leaf.entries[0].key}" to "${leaf.entries[leaf.entries.length-1].key}"`);
             options.applyChanges && options.applyChanges(newLeaf);
 
             // Start transaction
@@ -2075,7 +2075,7 @@ export class BinaryBPlusTree {
                 name: 'new leaf',
                 action: async () => {
                     const result = await this._writeLeaf(newLeaf);
-                    // console.log(`new leaf for entries "${newLeaf.entries[0].key}" to "${newLeaf.entries.slice(-1)[0].key}" was written successfully at index ${newLeaf.index} (used to be at ${leaf.index})`);
+                    // this.debug.log(`new leaf for entries "${newLeaf.entries[0].key}" to "${newLeaf.entries.slice(-1)[0].key}" was written successfully at index ${newLeaf.index} (used to be at ${leaf.index})`);
 
                     // // TEST leaf
                     // const leaf = await this._findLeaf(newLeaf.entries[0].key);
@@ -2230,7 +2230,7 @@ export class BinaryBPlusTree {
 
             const allocated = await this._requestFreeSpace(newNodeLength);
 
-            // console.log(`Splitting node "${node.entries[0].key}" to "${node.entries.slice(-1)[0].key}", cutting at "${movingEntries[0].key}"`);
+            // this.debug.log(`Splitting node "${node.entries[0].key}" to "${node.entries.slice(-1)[0].key}", cutting at "${movingEntries[0].key}"`);
 
             // Create new node
             const newNode = new BinaryBPlusTreeNode({
@@ -2256,7 +2256,7 @@ export class BinaryBPlusTree {
             //     newEntry.ltChildIndex = childIndex - newNode.index;
             //     newNode.entries.push(newEntry);
             // });
-            // console.log(`Creating new node for ${movingEntries.length} entries`);
+            // this.debug.log(`Creating new node for ${movingEntries.length} entries`);
 
             // Update parent node entry pointing to this node
             const oldParentNode = new BinaryBPlusTreeNode({
@@ -2350,7 +2350,7 @@ export class BinaryBPlusTree {
 
     async _splitLeaf(leaf: BinaryBPlusTreeLeaf, options: { nextLeaf?: BinaryBPlusTreeLeaf; keepEntries?: number; cancelCallback?: () => unknown } = { nextLeaf: null, keepEntries: 0, cancelCallback: null }) {
         // split leaf if it could not be written.
-        // console.log('splitLeaf');
+        // this.debug.log('splitLeaf');
         // There needs to be enough free space to store another leaf the size of current leaf
 
         if (typeof options.cancelCallback !== 'function') {
@@ -2433,7 +2433,7 @@ export class BinaryBPlusTree {
 
             const allocated = await this._requestFreeSpace(newLeafLength + newLeafExtDataLength);
 
-            // console.log(`Splitting leaf "${leaf.entries[0].key}" to "${leaf.entries.slice(-1)[0].key}", cutting at "${movingEntries[0].key}"`);
+            // this.debug.log(`Splitting leaf "${leaf.entries[0].key}" to "${leaf.entries.slice(-1)[0].key}", cutting at "${movingEntries[0].key}"`);
 
             const nextLeaf = options.nextLeaf;
 
@@ -2466,7 +2466,7 @@ export class BinaryBPlusTree {
             // move entries
             leaf.entries.splice(-movingEntries.length);
             newLeaf.entries.push(...movingEntries);
-            // console.log(`Creating new leaf for ${movingEntries.length} entries`);
+            // this.debug.log(`Creating new leaf for ${movingEntries.length} entries`);
 
             // Update parent node entry pointing to this leaf
             const oldParentNode = new BinaryBPlusTreeNode({
@@ -2575,8 +2575,8 @@ export class BinaryBPlusTree {
     //         leaf = await leaf.getNext();
     //         keys.push(...leaf.entries.map(e => e.key));
     //     }
-    //     console.warn(`TREE TEST: testing ${keys.length} keys`);
-    //     // console.warn(keys);
+    //     this.debug.warn(`TREE TEST: testing ${keys.length} keys`);
+    //     // this.debug.warn(keys);
     //     for (let i = 0; i < keys.length - 1; i++) {
     //         const key1 = keys[i], key2 = keys[i + 1];
     //         assert(_isLess(key1, key2), `Key "${key1}" must be smaller than "${key2}"`);
@@ -2587,7 +2587,7 @@ export class BinaryBPlusTree {
     //         const entry = leaf?.entries.find(e => e.key === key)
     //         assert(entry, `Key "${key}" must be in leaf`);
     //     }
-    //     console.warn(`TREE TEST: testing ext_data`);
+    //     this.debug.warn(`TREE TEST: testing ext_data`);
     //     leaf = await this._getFirstLeaf();
     //     while (leaf) {
     //         if (leaf.hasExtData) {
@@ -2610,7 +2610,7 @@ export class BinaryBPlusTree {
     //         }
     //         leaf = leaf.hasNext ? await leaf.getNext() : null;
     //     }
-    //     console.warn(`TREE TEST SUCCESSFUL`);
+    //     this.debug.warn(`TREE TEST SUCCESSFUL`);
     // }
 
     async add(key: NodeEntryKeyType, recordPointer: LeafEntryRecordPointer, metadata?: LeafEntryMetaData) {
@@ -2655,7 +2655,7 @@ export class BinaryBPlusTree {
                         catch(err) {
                             // Something went wrong adding the value. ext_data_block is probably full
                             // and needs to grow
-                            // console.log(`Leaf rebuild necessary - unable to add value to key "${key}": ${err.message}`);
+                            // this.debug.log(`Leaf rebuild necessary - unable to add value to key "${key}": ${err.message}`);
 
                             if (err.code !== 'max-extdata-size-reached') {
                                 throw err;
@@ -2753,7 +2753,7 @@ export class BinaryBPlusTree {
         // .then(() => {
         //     // TEST the tree adjustments by getting the leaf with the added key,
         //     // and then previous and next leafs!
-        //     console.warn(`TESTING leaf adjustment after adding "${key}". Remove code when all is well!`);
+        //     this.debug.warn(`TESTING leaf adjustment after adding "${key}". Remove code when all is well!`);
         //     return this._findLeaf(key);
         // })
         // .then(leaf => {
@@ -2829,18 +2829,18 @@ export class BinaryBPlusTree {
                     // Leaf too large to save, must split
                     const cancelCallback = () => undo.splice(0).reverse().forEach(fn => fn());
                     const keepEntries = leaf.hasNext ? 0 : this.info.entriesPerNode;
-                    // console.log('*process _splitLeaf');
+                    // this.debug.log('*process _splitLeaf');
                     await this._splitLeaf(leaf, { cancelCallback, keepEntries });
                 }
                 else if (leaf.entries.length > 0 || !leaf.parentNode) {
                     // Leaf has entries or is a single-leaf tree
                     try {
-                        // console.log('*process _writeLeaf');
+                        // this.debug.log('*process _writeLeaf');
                         await this._writeLeaf(leaf);
                     }
                     catch (err) {
                         // Leaf had no space left, try rebuilding it with more space
-                        // console.log('*process _rebuildLeaf');
+                        // this.debug.log('*process _rebuildLeaf');
                         await this._rebuildLeaf(leaf, {
                             growData: true,
                             growExtData: true,
@@ -2850,7 +2850,7 @@ export class BinaryBPlusTree {
                 }
                 else if (leaf.parentNode.entries.length > 1) {
                     // Remove leaf
-                    // console.log('*process _removeLeaf');
+                    // this.debug.log('*process _removeLeaf');
                     await this._removeLeaf(leaf);
                 }
                 else {
@@ -2931,7 +2931,7 @@ export class BinaryBPlusTree {
                         // debugRemoved.push(entry);
                         leaf.entries.splice(entryIndex, 1);
                         undo.push(() => {
-                            // console.log(`Undo remove ${entry.key}`);
+                            // this.debug.log(`Undo remove ${entry.key}`);
                             leaf.entries.splice(entryIndex, 0, entry);
                         });
                         // if (entryIndex === 0 && !leaf.parentEntry) {
@@ -2988,7 +2988,7 @@ export class BinaryBPlusTree {
         //     for (let removedEntry of debugRemoved) {
         //         const leaf = await this._findLeaf(removedEntry.key);
         //         if (leaf.entries.find(e => _isEqual(e.key, removedEntry.key))) {
-        //             console.log(debugThrownError);
+        //             this.debug.log(debugThrownError);
         //             debugger;
         //         }
         //     }
@@ -3347,7 +3347,7 @@ export class BinaryBPlusTree {
             }
         };
         // let leafsSeen = 0;
-        // console.log(`[${Date.toString()}] Starting tree rebuild`);
+        // this.debug.log(`[${Date.toString()}] Starting tree rebuild`);
         try {
             const getLeafStartKeys = async (entriesPerLeaf: number) => {
                 mark('getLeafStartKeys.start');
@@ -3361,7 +3361,7 @@ export class BinaryBPlusTree {
                 while (leaf) {
                     mark(`getLeafStartKeys.loop${loop++}`);
                     // leafsSeen++;
-                    // console.log(`Processing leaf with ${leaf.entries.length} entries, total=${totalEntries}`);
+                    // this.debug.log(`Processing leaf with ${leaf.entries.length} entries, total=${totalEntries}`);
                     // leafStats.debugEntries.push(...leaf.entries);
 
                     if (leaf.entries.length === 0) {
@@ -3482,10 +3482,10 @@ export class BinaryBPlusTree {
             mark('end');
             // if (perf) {
             //     // inspect perf here
-            //     console.log(`[perf] tree rebuild took ${measure('start', 'end')}ms`);
-            //     console.log(`[perf] getLeafStartKeys: ${measure('getLeafStartKeys.start', 'getLeafStartKeys.end')}ms`);
-            //     console.log(`[perf] getEntries: ${measure('getEntries.first', 'getEntries.last')}ms`);
-            //     console.log(`[perf] tree.create: ${measure('tree.createStart', 'tree.createEnd')}ms`);
+            //     this.debug.log(`[perf] tree rebuild took ${measure('start', 'end')}ms`);
+            //     this.debug.log(`[perf] getLeafStartKeys: ${measure('getLeafStartKeys.start', 'getLeafStartKeys.end')}ms`);
+            //     this.debug.log(`[perf] getEntries: ${measure('getEntries.first', 'getEntries.last')}ms`);
+            //     this.debug.log(`[perf] tree.create: ${measure('tree.createStart', 'tree.createEnd')}ms`);
             // }
         }
     }
@@ -3666,7 +3666,7 @@ export class BinaryBPlusTree {
                     emptyLeaf = true;
                 }
 
-                // console.log(`Writing leaf with ${entries.length} entries at index ${index}, keys range: ["${entries[0].key}", "${entries[entries.length-1].key}"]`)
+                // debug.log(`Writing leaf with ${entries.length} entries at index ${index}, keys range: ["${entries[0].key}", "${entries[entries.length-1].key}"]`)
                 // assert(entries.every((entry, index, arr) => index === 0 || _isMoreOrEqual(entry.key, arr[index-1].key)), 'Leaf entries are not sorted ok');
                 const i = leafIndexes.length;
                 // assert(emptyLeaf || _isEqual(leafStartKeys[i], entries[0].key), `first entry for leaf has wrong key, must be ${leafStartKeys[i]}!`);
@@ -3761,12 +3761,12 @@ export class BinaryBPlusTree {
             //     //     });
             //     // });
             //     // debugTree.reverse(); // Now top-down
-            //     // console.error(debugTree);
+            //     // debug.error(debugTree);
             //     // debugTree.forEach((nodes, levelIndex) => {
             //     //     let allEntries = nodes.map(node => `[${node.entries.map(entry => entry.key).join(',')}]`).join(' | ')
-            //     //     console.error(`node level ${levelIndex}: ${allEntries}`);
+            //     //     debug.error(`node level ${levelIndex}: ${allEntries}`);
             //     // });
-            //     // console.error(`leafs: [${leafStartKeys.join(`..] | [`)}]`);
+            //     // debug.error(`leafs: [${leafStartKeys.join(`..] | [`)}]`);
             // })
 
             // Now adjust the header data & write free bytes
@@ -3779,7 +3779,7 @@ export class BinaryBPlusTree {
             else {
                 // Use 10% free space, or the largest leaf length + 10%, or requested free leaf space, whichever is the largest
                 freeBytes = Math.max(Math.ceil(byteLength * 0.1), Math.ceil(largestLeafLength * 1.1), Math.ceil(Math.ceil((options.reserveSpaceForNewEntries || 0) / entriesPerLeaf) * largestLeafLength * 1.1));
-                // console.log(`new tree gets ${freeBytes} free bytes`);
+                // debug.log(`new tree gets ${freeBytes} free bytes`);
                 byteLength += freeBytes;
             }
 
@@ -3895,7 +3895,7 @@ export class BinaryBPlusTree {
                     const entryLength = await reader.getUint32();
                     if (options.treeStatistics.totalEntries % entriesPerLeaf === 1) {
                         const key = await reader.getValue();
-                        // console.log(key);
+                        // debug.log(key);
                         leafStartKeys.push(key);
                         await reader.go(entryIndex + entryLength);
                     }

--- a/src/data-index/data-index.ts
+++ b/src/data-index/data-index.ts
@@ -1803,6 +1803,7 @@ export class DataIndex {
                     isUnique: false,
                     keepFreeSpace: true,
                     metadataKeys: this.allMetadataKeys,
+                    debug: this.storage.debug,
                 },
             );
 

--- a/src/data-index/data-index.ts
+++ b/src/data-index/data-index.ts
@@ -2141,8 +2141,13 @@ export class DataIndex {
                 const result = await pfs.write(fd, buffer, 0, data.length, this.trees.default.fileIndex + index);
                 return result;
             };
-            const tree = new BinaryBPlusTree(reader, DISK_BLOCK_SIZE, writer);
-            tree.id = ID.generate(); // this.fileName; // For tree locking
+            const tree = new BinaryBPlusTree({
+                readFn: reader,
+                chunkSize: DISK_BLOCK_SIZE,
+                writeFn: writer,
+                debug: this.storage.debug,
+                id: ID.generate(), // For tree locking
+            });
             tree.autoGrow = true; // Allow the tree to grow. DISABLE THIS IF THERE ARE MULTIPLE TREES IN THE INDEX FILE LATER! (which is not implemented yet)
 
             this._idx = { fd, tree };

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -4036,9 +4036,8 @@ async function _writeNode(storage: AceBaseStorage, path: string, value: any, loc
 
     // Append all serialized data into 1 binary array
     let result: { keyTree: boolean, data: Uint8Array };
-    const minKeysPerNode = 25;
     const minKeysForTreeCreation = 100;
-    if (true && serialized.length > minKeysForTreeCreation) {
+    if (serialized.length > minKeysForTreeCreation) {
         // Create a B+tree
         const fillFactor =
             isArray || serialized.every(kvp => typeof kvp.key === 'string' && /^[0-9]+$/.test(kvp.key))

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -1213,6 +1213,75 @@ export class AceBaseStorage extends Storage {
         }
     }
 
+    /**
+     * Repairs a broken B+Tree key index of an object collection. Use this if you are unable to load every child of an object collection.
+     * @param path
+     */
+    async repairNodeTree(path: string) {
+        this.debug.warn(`Starting node tree repair for path "/${path}"`);
+        const tid = this.createTid();
+        let lock = await this.nodeLocker.lock(path, tid.toString(), true, 'repairNodeTree');
+        try {
+            // Make sure cache for parent and all children is removed
+            this.invalidateCache(false, path, true);
+
+            const nodeInfo = await (async () => {
+                try {
+                    return await this.getNodeInfo(path, { tid });
+                }
+                catch (err) {
+                    throw new Error(`Can't read parent node ${path}: ${err}`);
+                }
+            })();
+            if (!nodeInfo.exists) {
+                throw new Error(`Node at path ${path} does not exist`);
+            }
+            else if (!nodeInfo.address) {
+                throw new Error(`Node at ${path} is not stored in its own record`);
+            }
+
+            // Get the tree
+            const nodeReader = new NodeReader(this, nodeInfo.address, lock, false);
+            const recordInfo = await nodeReader.readHeader();
+            if (!recordInfo.hasKeyIndex) {
+                throw new Error(`Node at ${path} does not have a B+Tree key index`);
+            }
+            const tree = new BinaryBPlusTree({
+                readFn: nodeReader._treeDataReader.bind(nodeReader),
+                debug: this.debug,
+                id: `path:${path}`,
+            });
+            const newRecordInfo = await _rebuildKeyTree(tree, nodeReader, { repairMode: true });
+
+            if (newRecordInfo !== recordInfo) {
+                // deallocate old storage space & update parent address
+                const deallocate = new NodeAllocation(recordInfo.allocation.ranges);
+                const pathInfo = PathInfo.get(path);
+                if (pathInfo.parentPath !== null) {
+                    lock = await lock.moveToParent();
+                    await this._updateNode(
+                        pathInfo.parentPath,
+                        { [pathInfo.key]: new InternalNodeReference(newRecordInfo.valueType, newRecordInfo.address) },
+                        { merge: true, tid, _internal: true, context: { acebase_repair: { path, method: 'node-tree' } } },
+                    );
+                }
+                if (deallocate.totalAddresses > 0) {
+                    // Release record allocation marked for deallocation
+                    deallocate.normalize();
+                    this.debug.verbose(`Releasing ${deallocate.totalAddresses} addresses (${deallocate.ranges.length} ranges) previously used by node "/${path}" and/or descendants: ${deallocate}`.colorize(ColorStyle.grey));
+                    await this.FST.release(deallocate.ranges);
+                }
+            }
+            this.debug.warn(`Successfully repaired node tree for path "/${path}"`);
+        }
+        catch (err) {
+            this.debug.error(`Failed to repair node tree for path "/${path}": ${err.stack}`);
+        }
+        finally {
+            lock.release();
+        }
+    }
+
     get transactionLoggingEnabled() {
         return this.settings.transactions && this.settings.transactions.log === true;
     }
@@ -2993,8 +3062,11 @@ class NodeReader {
 
         // Gets children from a indexed binary tree of key/value data
         const createStreamFromBinaryTree = async () => {
-            const tree = new BinaryBPlusTree(this._treeDataReader.bind(this));
-            tree.id = `path:${this.address.path}`; // Prefix to fix #168
+            const tree = new BinaryBPlusTree({
+                readFn: this._treeDataReader.bind(this),
+                debug: this.storage.debug,
+                id: `path:${this.address.path}`, // Prefix to fix #168
+            });
 
             let canceled = false;
             if (options.keyFilter) {
@@ -3349,7 +3421,7 @@ class NodeReader {
             throw new Error(
                 `Attempt to read non-existing records of path "/${this.recordInfo.path}": ${startRecord.nr} to ${endRecord.nr + 1} ` +
                 `for index ${index} + ${length} bytes. Node has ${this.recordInfo.allocation.addresses.length} allocated records ` +
-                `in the following ranges: ` + this.recordInfo.allocation.ranges.toString()
+                `in the following ranges: ` + this.recordInfo.allocation.toString()
             );
         }
         const readRanges = NodeAllocation.fromAdresses(readRecords).ranges;
@@ -3469,12 +3541,13 @@ class NodeReader {
     getChildTree() {
         if (this.recordInfo === null) { throw new Error('record info hasn\'t been read yet'); }
         if (!this.recordInfo.hasKeyIndex) { throw new Error('record has no key index tree'); }
-        return new BinaryBPlusTree(
-            this._treeDataReader.bind(this),
-            1024 * 100, // 100KB reads/writes
-            this._treeDataWriter.bind(this),
-            'record@' + this.recordInfo.address.toString(),
-        );
+        return new BinaryBPlusTree({
+            readFn: this._treeDataReader.bind(this),
+            chunkSize: 1024 * 100, // 100KB reads/writes
+            writeFn: this._treeDataWriter.bind(this),
+            debug: this.storage.debug,
+            id: 'record@' + this.recordInfo.address.toString(),
+        });
     }
 }
 
@@ -3744,49 +3817,21 @@ async function _mergeNode(storage: AceBaseStorage, nodeInfo: BinaryNodeInfo, upd
                                 data = data.slice(0, length);
                             }
                         }
+                        if (sourceIndex === 0) {
+                            // Overwrite allocation bytes with new sizes.
+                            // Doing this in-memory helps prevent issue #183, if writing the new tree fails because of a storage issue
+                            tree.setAllocationBytes(data, bytesRequired, tree.info.freeSpace + growBytes);
+                        }
                         sourceIndex += data.byteLength;
                         return data;
                     };
-                    tree.info.byteLength = bytesRequired;
-                    tree.info.freeSpace += growBytes;
-                    await tree.writeAllocationBytes();
                     recordInfo = await _write(storage, nodeInfo.path, nodeReader.recordInfo.valueType, bytesRequired, true, reader, nodeReader.recordInfo);
                 }
                 else {
-                    // Failed to update the binary data, we need to recreate the whole tree
-                    // console.log(err);
-                    storage.debug.verbose('Tree needs rebuild');
+                    // Failed to update the binary data, we need to rebuild the tree
+                    storage.debug.verbose(`B+Tree for path ${nodeInfo.path} needs rebuild`);
                     fixHistory.push({ err, fix: 'rebuild' });
-
-                    // NEW: Rebuild tree to a temp file
-                    const tempFilepath = `${storage.settings.path}/${storage.name}.acebase/tree-${ID.generate()}.tmp`;
-                    let bytesWritten = 0;
-                    const fd = await pfs.open(tempFilepath, pfs.flags.readAndWriteAndCreate);
-                    const writer = BinaryWriter.forFunction(async (data, index) => {
-                        await pfs.write(fd, data, 0, data.length, index);
-                        bytesWritten += data.length;
-                    });
-                    await tree.rebuild(writer, { reserveSpaceForNewEntries: changes.inserts.length - changes.deletes.length }); // TODO: update changes with already processed!
-
-                    // Now write the record with data read from the temp file
-                    let readOffset = 0;
-                    const reader = async (length: number) => {
-                        const buffer = new Uint8Array(length);
-                        const { bytesRead } = await pfs.read(fd, buffer, 0, buffer.length, readOffset);
-                        readOffset += bytesRead;
-                        if (bytesRead < length) {
-                            return buffer.slice(0, bytesRead); // throw new Error(`Failed to read ${length} bytes from file, only got ${bytesRead}`);
-                        }
-                        return buffer;
-                    };
-                    recordInfo = await _write(storage, nodeInfo.path, nodeReader.recordInfo.valueType, bytesWritten, true, reader, nodeReader.recordInfo);
-                    // Close and remove the tmp file, don't wait for this
-                    pfs.close(fd)
-                        .then(() => pfs.rm(tempFilepath))
-                        .catch(err => {
-                            // Error removing the file?
-                            storage.debug.error(`Can't remove temp rebuild file ${tempFilepath}: `, err);
-                        });
+                    recordInfo = await _rebuildKeyTree(tree, nodeReader, { reserveSpaceForNewEntries: changes.inserts.length - changes.deletes.length });
                 }
 
                 if (recordInfo !== nodeReader.recordInfo) {
@@ -3798,12 +3843,13 @@ async function _mergeNode(storage: AceBaseStorage, nodeInfo: BinaryNodeInfo, upd
                 // Create new node reader and new tree
                 nodeReader = new NodeReader(storage, recordInfo.address, lock, false);
                 recordInfo = await nodeReader.readHeader();
-                tree = new BinaryBPlusTree(
-                    nodeReader._treeDataReader.bind(nodeReader),
-                    1024 * 100, // 100KB reads/writes
-                    nodeReader._treeDataWriter.bind(nodeReader),
-                    'record@' + nodeReader.recordInfo.address.toString(),
-                );
+                tree = new BinaryBPlusTree({
+                    readFn: nodeReader._treeDataReader.bind(nodeReader),
+                    chunkSize: 1024 * 100, // 100KB reads/writes
+                    writeFn: nodeReader._treeDataWriter.bind(nodeReader),
+                    debug: storage.debug,
+                    id: 'record@' + nodeReader.recordInfo.address.toString(),
+                });
 
                 // // Retry remaining operations
                 return processOperations(retry+1);
@@ -4479,6 +4525,47 @@ async function _write(
         storage.debug.error(`Failed to write node "/${path}": ${reason}`);
         throw reason;
     }
+}
+
+async function _rebuildKeyTree(tree: BinaryBPlusTree, nodeReader: NodeReader, options: Parameters<BinaryBPlusTree['rebuild']>[1]) {
+    const storage = nodeReader.storage;
+    const path = nodeReader.address.path;
+    const tempFilepath = `${storage.settings.path}/${storage.name}.acebase/tree-${ID.generate()}.tmp`;
+    let bytesWritten = 0;
+    const fd = await pfs.open(tempFilepath, pfs.flags.readAndWriteAndCreate);
+    const writer = BinaryWriter.forFunction(async (data, index) => {
+        await pfs.write(fd, data, 0, data.length, index);
+        bytesWritten += data.length;
+    });
+    await tree.rebuild(writer, options);
+
+    // Now write the record with data read from the temp file
+    let readOffset = 0;
+    const reader = async (length: number) => {
+        const buffer = new Uint8Array(length);
+        const { bytesRead } = await pfs.read(fd, buffer, 0, buffer.length, readOffset);
+        readOffset += bytesRead;
+        if (bytesRead < length) {
+            return buffer.slice(0, bytesRead); // throw new Error(`Failed to read ${length} bytes from file, only got ${bytesRead}`);
+        }
+        return buffer;
+    };
+    const newRecordInfo = await _write(storage, path, nodeReader.recordInfo.valueType, bytesWritten, true, reader, nodeReader.recordInfo);
+
+    console.assert(
+        newRecordInfo.allocation.totalAddresses * newRecordInfo.bytesPerRecord >= bytesWritten,
+        `insufficient space allocated for tree of path ${path}: ${newRecordInfo.allocation.totalAddresses} records for ${bytesWritten} bytes`
+    );
+
+    // Close and remove the tmp file, don't wait for this
+    pfs.close(fd)
+        .then(() => pfs.rm(tempFilepath))
+        .catch(err => {
+            // Error removing the file?
+            storage.debug.error(`Can't remove temp rebuild file ${tempFilepath}: `, err);
+        });
+
+    return newRecordInfo;
 }
 
 class InternalNodeReference {


### PR DESCRIPTION
Closes #183

Adds a recovery options that repairs damaged nodes that use a B+Tree to store its child keys.

Usage:  `await db.recovery.repairNodeTree(path)`  (execute once to fix)

This PR also prevents B+Trees from becoming damaged in the future if it grows, but fails to be rewritten to disk because of a filesystem error.