### PR TITLE
Empty keys pre-check

### DIFF
--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -3997,12 +3997,11 @@ async function _writeNode(storage: AceBaseStorage, path: string, value: any, loc
     else {
         // Store object
         Object.keys(value).forEach(key => {
-            // eslint-disable-next-line no-control-regex
             if (/[\x00-\x08\x0b\x0c\x0e-\x1f/[\]\\]/.test(key)) {
                 throw new Error(`Invalid key "${key}" for object to store at path "${path}". Keys cannot contain control characters or any of the following characters: \\ / [ ]`);
             }
             if (key.length > 128) { throw new Error(`Key "${key}" is too long to store for object at path "${path}". Max key length is 128`); }
-
+            if (key.length === 0) { throw new Error(`Child key for path "${path}" is not allowed be empty`); }
             const childPath = PathInfo.getChildPath(path, key); // `${path}/${key}`;
             const val = value[key];
             if (typeof val === 'function' || val === null) {

--- a/src/test/keys.spec.ts
+++ b/src/test/keys.spec.ts
@@ -29,6 +29,26 @@ describe('Keys', () => {
 
     });
 
+    it('should not allow empty keys', async () => {
+        // Created for issue #172 (https://github.com/appy-one/acebase/issues/172)
+        // Test what happens with child ''
+        try {
+            db.ref('empty-keys').child('');
+            fail('ref.child should not allow empty keys');
+        }
+        catch (err) {
+            // ok
+        }
+
+        // Test 'set' operation
+        let p = db.ref('empty-keys').set({ '': 'Empty key name must not be allowed' });
+        await expectAsync(p).toBeRejected();
+
+        // Test 'update' operation
+        p = db.ref('empty-keys').update({ '': 'Empty key name must not be allowed' });
+        await expectAsync(p).toBeRejected();
+    });
+
     it('should not allow special characters \\ / [ ] ', async () => {
 
         let p = db.ref('invalid').set({ 'forward/slash': 'Forward slashes are used to access nested objects' });


### PR DESCRIPTION
Adds a pre-check to prevent empty `''` keys to be used in `update` and `set` objects. This has already been fixed in `acebase-core` by https://github.com/appy-one/acebase-core/pull/24, added here to keep checks the same. Another option would be to to remove the key checks here and completely delegate it to `acebase-core`'s `PathInfo` class. This should be considered.

Also adds unit tests