### PR TITLE
Add eslint `curly` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,8 @@
             "functions": "only-multiline"
         }],
         "no-trailing-spaces": "error",
-        "eol-last": "error"
+        "eol-last": "error",
+        "curly": "error"
     },
     "overrides": [{
         "files": "*.js",


### PR DESCRIPTION
Do not allow single block statements without `{ }`