### PR TITLE
Allow wildcard path queries with given filter values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/acebase-core": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.25.0.tgz",
-      "integrity": "sha512-d7Bh0tcYYCcdKLYu7lDYPhDOIZQObUwGiMg4mcMfsdWWdlfQyQqQMLkYVRqVH1OdHHXEx/BoqtH1oHkEBqgRZg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.0.tgz",
+      "integrity": "sha512-u7cyudMd8dCI9whKCNjxxvphwIAJfE9+6+0Omcjv6IS/lxaOzShlyuPPp0BpvsvsVt0B6UxoGL729l4x2VFXFQ==",
       "optionalDependencies": {
         "rxjs": ">= 5.x <= 7.x"
       }
@@ -4734,9 +4734,9 @@
       }
     },
     "acebase-core": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.25.0.tgz",
-      "integrity": "sha512-d7Bh0tcYYCcdKLYu7lDYPhDOIZQObUwGiMg4mcMfsdWWdlfQyQqQMLkYVRqVH1OdHHXEx/BoqtH1oHkEBqgRZg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.0.tgz",
+      "integrity": "sha512-u7cyudMd8dCI9whKCNjxxvphwIAJfE9+6+0Omcjv6IS/lxaOzShlyuPPp0BpvsvsVt0B6UxoGL729l4x2VFXFQ==",
       "requires": {
         "rxjs": ">= 5.x <= 7.x"
       }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "author": "Ewout Stortenbeker <me@appy.one> (http://appy.one)",
   "license": "MIT",
   "dependencies": {
-    "acebase-core": "^1.25.0",
+    "acebase-core": "^1.26.0",
     "unidecode": "^0.1.8"
   },
   "devDependencies": {

--- a/src/api-local.ts
+++ b/src/api-local.ts
@@ -303,7 +303,7 @@ export class LocalApi extends Api {
                         recordNr: (nodeInfo.address as BinaryNodeAddress).recordNr,
                     }
                     : undefined;
-                const isObjectOrArray = nodeInfo.exists && nodeInfo.address && [VALUE_TYPES.OBJECT, VALUE_TYPES.ARRAY].includes(nodeInfo.type);
+                const isObjectOrArray = nodeInfo.exists && nodeInfo.address && ([VALUE_TYPES.OBJECT, VALUE_TYPES.ARRAY] as number[]).includes(nodeInfo.type);
                 if (args.child_count === true) {
                     // set child count instead of enumerating
                     info.children = { count: isObjectOrArray ? nodeInfo.childCount : 0 };

--- a/src/api-local.ts
+++ b/src/api-local.ts
@@ -7,7 +7,7 @@ import { SQLiteStorage, SQLiteStorageSettings } from './storage/sqlite';
 import { MSSQLStorage, MSSQLStorageSettings } from './storage/mssql';
 import { CustomStorage, CustomStorageSettings } from './storage/custom';
 import { VALUE_TYPES } from './node-value-types';
-import { query as executeQuery } from './query';
+import { executeQuery } from './query';
 import { Storage, StorageEnv } from './storage';
 import { CreateIndexOptions } from './storage/indexes';
 import type { BinaryNodeAddress } from './storage/binary/node-address';

--- a/src/query.ts
+++ b/src/query.ts
@@ -676,11 +676,10 @@ export async function executeQuery(
             if (options.monitor === true) {
                 options.monitor = { add: true, change: true, remove: true };
             }
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            let stop = async () => {};
             if (typeof options.monitor === 'object' && (options.monitor.add || options.monitor.change || options.monitor.remove)) {
                 // TODO: Refactor this to use 'mutations' event instead of 'notify_child_*'
 
+                const monitor = options.monitor;
                 const matchedPaths = options.snapshots ? matches.map(match => match.path) : matches.slice();
                 const ref = api.db.ref(path);
                 const removeMatch = (path: string) => {
@@ -770,16 +769,16 @@ export async function executeQuery(
                             const node = await api.storage.getNode(path, loadOptions);
                             newValue = node.value;
                         }
-                        if (wasMatch && options.monitor.change) {
+                        if (wasMatch && monitor.change) {
                             keepMonitoring = options.eventHandler({ name: 'change', path, value: newValue }) !== false;
                         }
-                        else if (!wasMatch && options.monitor.add) {
+                        else if (!wasMatch && monitor.add) {
                             keepMonitoring = options.eventHandler({ name: 'add', path, value: newValue }) !== false;
                         }
                     }
                     else if (wasMatch) {
                         removeMatch(path);
-                        if (options.monitor.remove) {
+                        if (monitor.remove) {
                             keepMonitoring = options.eventHandler({ name: 'remove', path: path, value: oldValue }) !== false;
                         }
                     }
@@ -797,7 +796,7 @@ export async function executeQuery(
                     let keepMonitoring = true;
                     if (isMatch) {
                         addMatch(path);
-                        if (options.monitor.add) {
+                        if (monitor.add) {
                             keepMonitoring = options.eventHandler({ name: 'add', path: path, value: options.snapshots ? newValue : null }) !== false;
                         }
                     }
@@ -806,7 +805,7 @@ export async function executeQuery(
                 const childRemovedCallback: EventSubscriptionCallback = (err, path, newValue, oldValue) => {
                     let keepMonitoring = true;
                     removeMatch(path);
-                    if (options.monitor.remove) {
+                    if (monitor.remove) {
                         keepMonitoring = options.eventHandler({ name: 'remove', path: path, value: options.snapshots ? oldValue : null }) !== false;
                     }
                     if (keepMonitoring === false) { stopMonitoring(); }

--- a/src/query.ts
+++ b/src/query.ts
@@ -25,7 +25,7 @@ const noop = () => {};
  * @param options Additional options
  * @returns Returns a promise that resolves with matching data or paths in `results`
  */
-export function query(
+export async function executeQuery(
     api: LocalApi,
     path: string,
     query: Query,
@@ -36,7 +36,6 @@ export function query(
     stop(): Promise<void>
 }> {
     // TODO: Refactor to async
-
     if (typeof options !== 'object') { options = {}; }
     if (typeof options.snapshots === 'undefined') { options.snapshots = false; }
 
@@ -115,8 +114,72 @@ export function query(
 
     const availableIndexes = api.storage.indexes.get(path);
     const usingIndexes = [] as Array<{ index: DataIndex; description: string }>;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    let stop = async () => {};
+
     if (isWildcardPath) {
-        if (availableIndexes.length === 0) {
+        // Check if path contains $vars with explicit filter values. If so, execute multiple queries and merge results
+        const vars = pathInfo.keys.filter(key => typeof key === 'string' && key.startsWith('$'));
+        const hasExplicitFilterValues = vars.length > 0 && vars.every(v => query.filters.some(f => f.key === v && ['==', 'in'].includes(f.op)));
+        const isRealtime = typeof options.monitor === 'object' && [options.monitor?.add, options.monitor?.change, options.monitor?.remove].some(val => val === true);
+        if (hasExplicitFilterValues && !isRealtime) {
+            // create path combinations
+            const combinations = [] as Record<string, string>[];
+            for (const v of vars) {
+                const filters = query.filters.filter(f => f.key === v);
+                const filterValues = filters.reduce((values, f) => {
+                    if (f.op === '==') { values.push(f.compare); }
+                    if (f.op === 'in') {
+                        if (!(f.compare instanceof Array)) { throw new Error(`compare argument for 'in' operator must be an Array`); }
+                        values.push(...f.compare);
+                    }
+                    return values;
+                }, [] as string[]);
+                // Expand all current combinations with these filter values
+                const prevCombinations = combinations.splice(0);
+                filterValues.forEach(fv => {
+                    if (prevCombinations.length === 0) {
+                        combinations.push({ [v]: fv });
+                    }
+                    else {
+                        combinations.push(...prevCombinations.map(c => ({ ...c, [v]: fv })));
+                    }
+                });
+            }
+            // create queries
+            const filters = query.filters.filter(f => !vars.includes(f.key as string));
+            const paths = combinations.map(vars => PathInfo.get(PathInfo.getPathKeys(path).map(key => vars[key] ?? key)).path);
+            const loadData = query.order.length > 0;
+            const promises = paths.map(path => executeQuery(
+                api,
+                path,
+                { filters, take: 0, skip: 0, order: [] },
+                {
+                    snapshots: loadData,
+                    cache_mode: options.cache_mode,
+                    include: [...(options.include ?? []), ...query.order.map(o => o.key)],
+                    exclude: options.exclude,
+                }
+            ));
+            const resultSets = await Promise.all(promises);
+            let results = resultSets.reduce((results, set) => (results.push(...set.results), results), [] as any[]);
+            if (loadData) {
+                sortMatches(results);
+            }
+            if (query.skip > 0) {
+                results.splice(0, query.skip);
+            }
+            if (query.take > 0) {
+                results.splice(query.take);
+            }
+            if (options.snapshots && (!loadData || options.include?.length > 0 || options.exclude?.length > 0 || !options.child_objects)) {
+                const { include, exclude, child_objects } = options;
+                results = await loadResultsData(results, { include, exclude, child_objects });
+            }
+            return { results, context: null, stop };
+            // const results = options.snapshots ? results
+        }
+        else if (availableIndexes.length === 0) {
             // Wildcard paths require data to be indexed
             const err = new Error(`Query on wildcard path "/${path}" requires an index`);
             return Promise.reject(err);

--- a/src/test/query.spec.ts
+++ b/src/test/query.spec.ts
@@ -479,6 +479,22 @@ describe('Wildcard query', () => {
         }
     }, 60e3); // increased timeout for debugging
 
+    it('wildcards with explicit filter value', async () => {
+
+        // Insert data without index
+        await db.ref('other_users/user1/messages').push({ text: 'First message' });
+        await db.ref('other_users/user2/messages').push({ text: 'Second message' });
+        await db.ref('other_users/user1/messages').push({ text: 'Third message' });
+
+        let promise = db.query('other_users/$username/messages').filter('$username', '==', 'user1').count();
+        await expectAsync(promise).toBeResolvedTo(2);
+        promise = db.query('other_users/$username/messages').filter('$username', '==', 'user2').count();
+        await expectAsync(promise).toBeResolvedTo(1);
+        promise = db.query('other_users/$username/messages').filter('$username', 'in', ['user1', 'user2']).count();
+        await expectAsync(promise).toBeResolvedTo(3);
+
+    }, 60e3); // increased timeout for debugging
+
 });
 
 describe('Wildcard query with delete', () => {


### PR DESCRIPTION
Allows queries to be executed on non-indexed paths with $variables if values for those variables are passed as a filter.

Example:
```js
const messageCount = await db.query('users/$username/messages').filter('$username', 'in', ['user1', 'user2']).count();
```

Above essentially performs 2 queries (for user1 and user2) and combines the results