### PR TITLE
Fix writing inline keys with unicode chars

### DIFF
--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -3270,11 +3270,7 @@ class NodeReader {
                                 const keyLength = (binary[index] & 127) + 1;
                                 index++;
                                 assert(keyLength);
-                                let key = '';
-                                for(let i = 0; i < keyLength; i++) {
-                                    key += String.fromCharCode(binary[index + i]);
-                                }
-
+                                const key = decodeString(binary.slice(index, index + keyLength));
                                 child.key = key;
                                 child.path = PathInfo.getChildPath(this.address.path, key);
                                 index += keyLength;
@@ -4074,10 +4070,9 @@ async function _writeNode(storage: AceBaseStorage, path: string, value: any, loc
                 }
                 else {
                     // Inline key name
-                    builder.writeByte(kvp.key.length - 1); // key_length
-                    // key_name:
                     const keyBytes = encodeString(kvp.key);
-                    builder.append(keyBytes);
+                    builder.writeByte(keyBytes.byteLength - 1); // key_length
+                    builder.append(keyBytes); // key_name
                 }
             }
             // const binaryValue = _getValueBytes(kvp);


### PR DESCRIPTION
Fixes the issue where keys with unicode characters are not correctly written to the db causing them to become unreadable. This only was able to happen if the internal Key Index Table was full, or if IPC was used in clustering mode. This will not fix existing data, but does prevent it from happening in the future. If you have a broken db because of this issue and want it fixed, let me know. Fixes #209 