### PR TITLE
New feature: socket IPC service

### DIFF
--- a/src/ipc/service/index.ts
+++ b/src/ipc/service/index.ts
@@ -1,0 +1,90 @@
+import { createServer, Socket } from 'net';
+import { getSocketPath } from './shared';
+import { AceBase } from '../../';
+
+const ERROR = Object.freeze({
+    ALREADY_RUNNING: { code: 'already_running', exitCode: 2 },
+    UNKNOWN: { code: 'unknown', exitCode: 3 },
+    NO_DB: { code: 'no_db', exitCode: 4 },
+});
+
+export async function startServer(dbFile: string, exit: (code: number) => void) {
+
+    const fileMatch = dbFile.match(/^(?<storagePath>.*([\\\/]))(?<dbName>.+)\.acebase\2(?<storageType>[a-z]+)\.db$/);
+    if (!fileMatch) {
+        return exit(ERROR.NO_DB.exitCode);
+    }
+    const { storagePath, dbName, storageType } = fileMatch.groups;
+    let db: AceBase; // Will be opened when listening
+
+    const sockets = [] as Socket[];
+
+    const socketPath = getSocketPath(dbFile);
+    console.log(`starting socket server on path ${socketPath}`);
+
+    const server = createServer();
+    server.listen({
+        path: socketPath,
+        readableAll: true,
+        writableAll: true,
+    });
+
+    server.on('listening', () => {
+        // Started successful
+        // state = STATE.STARTED;
+        // process.send(`state:${state}`);
+        process.on('SIGINT', () => server.close());
+        process.on('exit', (code) => {
+            console.log(`exiting with code ${code}`);
+        });
+
+        // Start the "master" IPC client
+        db = new AceBase(dbName, { storage: { type: storageType, path: storagePath, ipc: server } });
+        // Bind socket server to the instance
+        // (db.api.storage.ipc as IPCSocketPeer).server = server;
+    });
+
+    server.on('error', (err: Error & { code: string }) => {
+        // state = STATE.ERROR;
+        // process.send(`state:${state}`);
+        // process.send(`error:${err.code ?? err.message}`);
+        if (err.code === 'EADDRINUSE') {
+            console.log('socket server already running');
+            return exit(ERROR.ALREADY_RUNNING.exitCode);
+        }
+        console.error(`socket server error ${err.code ?? err.message}`);
+        exit(ERROR.UNKNOWN.exitCode);
+    });
+
+    server.on('connection', (socket) => {
+        // New socket connected handler
+        sockets.push(socket);
+        console.log(`socket connected, total: ${sockets.length}`);
+
+        // socket.on('data', (data) => {
+        //     // Received data from a connected client (master or worker)
+        //     // Socket IPC implementation handles this
+        // });
+
+        socket.on('close', (hadError) => {
+            // Socket is closed
+            sockets.splice(sockets.indexOf(socket), 1);
+            console.log(`socket disconnected${hadError ? ' because of an error' : ''}, total: ${sockets.length}`);
+            if (sockets.length === 0) {
+                // setTimeout(() => {
+                //     if (sockets.length === 0) {
+                console.log(`closing server socket because there are no more connected clients, exiting with code 0`);
+                // Stop socket server
+                server.close((err) => {
+                    exit(0);
+                });
+                //     }
+                // }, 5000);
+            }
+        });
+    });
+
+    server.on('close', () => {
+        db.close();
+    });
+}

--- a/src/ipc/service/shared.ts
+++ b/src/ipc/service/shared.ts
@@ -1,0 +1,8 @@
+export function getSocketPath(filePath: string) {
+    return process.platform ==='win32'
+        ? `\\\\.\\pipe\\${filePath.replace(/^\//, '').replace(/\//g, '-')}`
+        : `${filePath}.sock`;
+}
+
+// export const MSG_DELIMITER = String.fromCharCode(0) + String.fromCharCode(1) + String.fromCharCode(3) + String.fromCharCode(5) + String.fromCharCode(0);
+export const MSG_DELIMITER = '\n';

--- a/src/ipc/service/start.ts
+++ b/src/ipc/service/start.ts
@@ -1,0 +1,14 @@
+import { startServer } from '.';
+
+(async () => {
+    try {
+        const dbFile = process.argv[2]; // full path to db storage file, eg '/home/ewout/project/db.acebase/data.db'
+        await startServer(dbFile, (code) => {
+            process.exit(code);
+        });
+    }
+    catch (err) {
+        console.error(`Start error:`, err);
+        process.exit(1);
+    }
+})();

--- a/src/ipc/socket.ts
+++ b/src/ipc/socket.ts
@@ -1,0 +1,255 @@
+import { Socket, connect, Server } from 'net';
+import { resolve as resolvePath } from 'path';
+import { fork } from 'child_process';
+import { AceBaseIPCPeer, IHelloMessage, IMessage } from './ipc';
+import { Storage } from '../storage';
+import { ID, Transport } from 'acebase-core';
+import { getSocketPath, MSG_DELIMITER } from './service/shared';
+import { startServer } from './service';
+
+const masterPeerId = '[master]';
+
+interface EventEmitterLike {
+    addListener?(event: string, handler: (...args: any[]) => any): any;
+    removeListener?(event: string, handler: (...args: any[]) => any): any;
+    on?(event: string, handler: (...args: any[]) => any): any;
+    off?(event: string, handler: (...args: any[]) => any): any;
+}
+
+/**
+ * Node cluster functionality - enables vertical scaling with forked processes. AceBase will enable IPC at startup, so
+ * any forked process will communicate database changes and events automatically. Locking of resources will be done by
+ * the cluster's primary (previously master) process. NOTE: if the master process dies, all peers stop working
+ */
+export class IPCSocketPeer extends AceBaseIPCPeer {
+
+    public server?: Server;
+
+    constructor(storage: Storage, ipcSettings: { ipcName: string; server: Server | null }) {
+
+        const isMaster = storage.settings.ipc instanceof Server;
+        const peerId = isMaster ? masterPeerId : ID.generate();
+        super(storage, peerId, ipcSettings.ipcName);
+        this.server = ipcSettings.server;
+
+        this.masterPeerId = masterPeerId;
+        this.ipcType = 'node.socket';
+
+        const dbFile = resolvePath(storage.path, `${storage.settings.type}.db`);
+        const socketPath = getSocketPath(dbFile);
+
+        /** Adds an event handler that is automatically removed upon IPC exit */
+        const bindEventHandler = (target: EventEmitterLike, event: string, handler: (...args: any[]) => any) => {
+            (target.on ?? target.addListener).bind(target)(event, handler);
+            this.on('exit', () => (target.off ?? target.removeListener).bind(target)(event, handler));
+        };
+
+        // Setup process exit handler
+        bindEventHandler(process, 'SIGINT', () => {
+            this.exit();
+        });
+
+        if (!isMaster) {
+            // Try starting IPC service if it is not running yet
+            const service = fork(__dirname + '/service/start.js', [dbFile], { detached: true, stdio: 'inherit' });
+            service.unref(); // Process is detached and allowed to keep running after we exit
+            bindEventHandler(service, 'exit', (code, signal) => {
+                console.log(`Service exited with code ${code}`);
+            });
+
+            // // For testing:
+            // startServer(dbFile, (code) => {
+            //     console.log(`Service exited with code ${code}`);
+            // });
+        }
+
+        /**
+         * Socket connection with master (workers only)
+         */
+        let socket: Socket | null = null;
+        let connected = false;
+        const queue = [] as IMessage[];
+
+        /**
+         * Maps peers to IPC sockets (master only)
+         */
+        const peerSockets = isMaster ? new Map<string, Socket>() : null;
+
+        const handleMessage = (socket: Socket, message: IMessage) => {
+            if (typeof message !== 'object') {
+                // Ignore non-object IPC messages
+                return;
+            }
+            if (isMaster && message.to !== masterPeerId) {
+                // Message is meant for others (or all). Forward it
+                this.sendMessage(message);
+            }
+            if (message.to && message.to !== this.id) {
+                // Message is for somebody else. Ignore
+                return;
+            }
+            if (this.isMaster) {
+                if (message.type === 'hello') {
+                    // Bind peer id to incoming socket
+                    peerSockets.set(message.from, socket);
+                }
+                else if (message.type === 'bye') {
+                    // Remove bound socket for peer
+                    peerSockets.delete(message.from);
+                }
+            }
+            return super.handleMessage(message);
+        };
+
+        if (isMaster) {
+            this.server.on('connection', (socket) => {
+                // New socket connected. We don't know which peer it is until we get a "hello" message
+                let buffer = Buffer.alloc(0); // Buffer to store incomplete messages
+                socket.on('data', chunk => {
+                    // Received data from a worker
+                    buffer = Buffer.concat([buffer, chunk]);
+
+                    while (buffer.length > 0) {
+                        const delimiterIndex = buffer.indexOf(MSG_DELIMITER);
+                        if (delimiterIndex === -1) {
+                            break; // wait for more data
+                        }
+
+                        // Extract message from buffer
+                        const message = buffer.slice(0, delimiterIndex);
+                        buffer = buffer.slice(delimiterIndex + MSG_DELIMITER.length);
+
+                        try {
+                            const json = message.toString('utf-8');
+                            // console.log(`Received socket message: `, json);
+                            const serialized = JSON.parse(json);
+                            const msg = Transport.deserialize2(serialized);
+                            handleMessage(socket, msg);
+                        }
+                        catch (err) {
+                            console.error(`Error parsing message: ${err}`);
+                        }
+                    }
+                });
+                socket.on('close', (hadError) => {
+                    // socket has disconnected. Find registered peer
+                    for (const [peerId, peerSocket] of peerSockets.entries()) {
+                        if (peerSocket === socket) {
+                            // Worker apparently did not have time to say goodbye,
+                            // remove the peer ourselves
+                            this.removePeer(peerId);
+
+                            // Send "bye" message on their behalf
+                            this.sayGoodbye(peerId);
+                            break;
+                        }
+                    }
+                });
+            });
+        }
+        else {
+            const connectSocket = async (path: string) => {
+                const tryConnect = async (tries: number): Promise<void> => {
+                    try {
+                        const s = connect({ path });
+                        await new Promise<void>((resolve, reject) => {
+                            s.once('error', reject);
+                            s.once('connect', resolve);
+                        });
+                        console.log(`IPC peer ${this.id} successfully established connection to the server`);
+                        socket = s;
+                        connected = true;
+                    }
+                    catch (err) {
+                        if (tries < 100) {
+                            // Retry in 10ms
+                            await new Promise(resolve => setTimeout(resolve, 100));
+                            return tryConnect(tries + 1);
+                        }
+                        console.error(err.message);
+                        throw err;
+                    }
+                };
+                await tryConnect(1);
+
+                this.once('exit', () => {
+                    socket.destroy();
+                });
+
+                bindEventHandler(socket, 'close', (hadError) => {
+                    // Connection to server closed
+                    console.log(`IPC peer ${this.id} lost its connection to the server${hadError ? ' because of an error' : ''}`);
+                });
+
+                let buffer = Buffer.alloc(0); // Buffer to store incomplete messages
+                bindEventHandler(socket, 'data', chunk => {
+                    // Received data from server
+                    buffer = Buffer.concat([buffer, chunk]);
+
+                    while (buffer.length > 0) {
+                        const delimiterIndex = buffer.indexOf(MSG_DELIMITER);
+                        if (delimiterIndex === -1) {
+                            break; // wait for more data
+                        }
+
+                        // Extract message from buffer
+                        const message = buffer.slice(0, delimiterIndex);
+                        buffer = buffer.slice(delimiterIndex + MSG_DELIMITER.length);
+
+                        try {
+                            const json = message.toString('utf-8');
+                            // console.log(`Received server message: `, json);
+                            const serialized = JSON.parse(json);
+                            const msg = Transport.deserialize2(serialized);
+                            handleMessage(socket, msg);
+                        }
+                        catch (err) {
+                            console.error(`Error parsing message: ${err}`);
+                        }
+                    }
+                });
+
+                connected = true;
+                while (queue.length) {
+                    const message = queue.shift();
+                    this.sendMessage(message);
+                }
+            };
+            connectSocket(socketPath);
+        }
+
+        this.sendMessage = (message: IMessage) => {
+            const serialized = Transport.serialize2(message);
+            const buffer = Buffer.from(JSON.stringify(serialized) + MSG_DELIMITER);
+            if (this.isMaster) {
+                // We are the master, send the message to the target worker(s)
+                this.peers
+                    .filter(p => p.id !== message.from && (!message.to || p.id === message.to))
+                    .forEach(peer => {
+                        const socket = peerSockets.get(peer.id);
+                        socket?.write(buffer);
+                    });
+            }
+            else if (connected) {
+                // Send the message to the master who will forward it to the target worker(s)
+                socket.write(buffer);
+            }
+            else {
+                // Not connected yet, queue message
+                queue.push(message);
+            }
+        };
+
+        // Send hello to other peers
+        const helloMsg: IHelloMessage = { type: 'hello', from: this.id, data: undefined };
+        this.sendMessage(helloMsg);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    sendMessage(message: IMessage) { throw new Error('Must be set by constructor'); }
+
+    public async exit(code = 0) {
+        await super.exit(code);
+    }
+
+}

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -886,7 +886,7 @@ export class AceBaseStorage extends Storage {
                     const exists = await pfs.exists(this.fileName);
                     if (exists) { openDatabaseFile(); }
                     else { poll(); }
-                }, 10); // Wait 10ms before trying again
+                }, 1000); // Wait 1s before trying again
             };
             poll();
         }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -9,6 +9,8 @@ import { DataIndex } from '../data-index'; // Indexing might not be available: t
 import { createIndex, CreateIndexOptions } from './indexes';
 import { IndexesContext } from './context';
 import { assert } from '../assert';
+import { IPCSocketPeer } from '../ipc/socket';
+import { Server } from 'net';
 
 const { compareValues, getChildValues, encodeString, defer } = Utils;
 
@@ -109,9 +111,10 @@ export class StorageSettings {
     readOnly = false;
 
     /**
-     * IPC settings if you are using AceBase in pm2 or cloud-based clusters
+     * IPC settings if you are using AceBase in pm2 or cloud-based clusters, or (NEW) `'socket'` to connect
+     * to an automatically spawned IPC service ("daemon") on this machine
      */
-    ipc?: IPCClientSettings;
+    ipc?: IPCClientSettings | 'socket' | Server;
 
     /**
      * Settings for optional transaction logging
@@ -126,7 +129,7 @@ export class StorageSettings {
         if (typeof settings.lockTimeout === 'number') { this.lockTimeout = settings.lockTimeout; }
         if (typeof settings.type === 'string') { this.type = settings.type; }
         if (typeof settings.readOnly === 'boolean') { this.readOnly = settings.readOnly; }
-        if (typeof settings.ipc === 'object') { this.ipc = settings.ipc; }
+        if (['object', 'string'].includes(typeof settings.ipc)) { this.ipc = settings.ipc; }
     }
 }
 
@@ -143,7 +146,7 @@ export class Storage extends SimpleEventEmitter {
     public debug: DebugLogger;
     public stats: any;
 
-    public ipc: IPCPeer | RemoteIPCPeer;
+    public ipc: IPCPeer | RemoteIPCPeer | IPCSocketPeer;
     public nodeLocker: {
         lock(path: string, tid: string, write: boolean, comment?: string): ReturnType<IPCPeer['lock']>;
     };
@@ -169,7 +172,11 @@ export class Storage extends SimpleEventEmitter {
 
         // Setup IPC to allow vertical scaling (multiple threads sharing locks and data)
         const ipcName = name + (typeof settings.type === 'string' ? `_${settings.type}` : '');
-        if (settings.ipc) {
+        if (settings.ipc === 'socket' || settings.ipc instanceof Server) {
+            const ipcSettings = { ipcName, server: settings.ipc instanceof Server ? settings.ipc : null };
+            this.ipc = new IPCSocketPeer(this, ipcSettings);
+        }
+        else if (settings.ipc) {
             if (typeof settings.ipc.port !== 'number') {
                 throw new Error('IPC port number must be a number');
             }
@@ -704,7 +711,6 @@ export class Storage extends SimpleEventEmitter {
                 const trailKeys = pathKeys.slice(eventPathKeys.length);
                 let currentValue = topEventData;
                 while (trailKeys.length > 0 && currentValue !== null) {
-                    /** @type {string|number} trailKeys.shift() as string|number */
                     const childKey = trailKeys.shift();
                     currentValue = typeof currentValue === 'object' && childKey in currentValue ? currentValue[childKey] : null;
                 }

--- a/src/test/tempdb.ts
+++ b/src/test/tempdb.ts
@@ -11,6 +11,7 @@ export async function createTempDB(enable: { transactionLogging?: boolean; logLe
     if (typeof enable.config === 'function') {
         enable.config(options);
     }
+    options.storage.ipc = 'socket';
     const db = new AceBase(dbname, options);
     await db.ready();
 


### PR DESCRIPTION
This approach automatically starts a service ("daemon") for the target database in a separate process. The service will take on the master/primary role, all connecting clients will take on the worker role. This mode should become the default in the near future, as it eliminates the need to manually setup local master/worker clustering settings. It will also enable one to simultaneously use a single database file from different apps, which would previously require setting up an AceBaseServer!