### PR TITLE
Fixes #203 / #219

### DIFF
--- a/create-package-files
+++ b/create-package-files
@@ -43,7 +43,7 @@ JSON
 
 # Write typings to support Node16 module resolution 
 cat >dist/esm/index.d.ts <<TYPESCRIPT
-export * from '../types';
+export * from '../types/index.d.ts';
 TYPESCRIPT
 
 # Write example file for runkit


### PR DESCRIPTION
Fixes using AceBase from TypeScript ES modules (`"type": "module"` in _package.json_) and `"moduleResolution": "node16"` or `"moduleResolution": "nodenext"` in _tsconfig.json_

This adds `/index.d.ts` to the `export * from "../types"` statement in the generated _/dist/esm/index.d.ts_

Closes #203 and #219