### PR TITLE
fix tsc node16 module resolution

### DIFF
--- a/create-package-files
+++ b/create-package-files
@@ -20,7 +20,7 @@ JSON
 
 # Write typings to support Node16 module resolution 
 cat >dist/cjs/index.d.ts <<TYPESCRIPT
-export * from '../types';
+export * from '../types/index.js';
 TYPESCRIPT
 
 # Create ESM package.json
@@ -43,7 +43,7 @@ JSON
 
 # Write typings to support Node16 module resolution 
 cat >dist/esm/index.d.ts <<TYPESCRIPT
-export * from '../types/index.d.ts';
+export * from '../types/index.js';
 TYPESCRIPT
 
 # Write example file for runkit

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
     "compilerOptions": {
         "lib": ["esnext","dom"],
-        "listEmittedFiles": true,
+        "listEmittedFiles": false,
         "noImplicitAny": true,
         "sourceMap": true,
         "module": "es2020",
+        "rootDir": "./src",
         "outDir": "./dist/esm",
         "moduleResolution": "node",
         "target": "es2020",
@@ -13,10 +14,6 @@
         "declarationMap": true,
         "declarationDir": "./dist/types",
         "resolveJsonModule": true,
-        "skipLibCheck": true
-    },
-    "include": ["src/**/*"],
-    "exclude": [
-        "node_modules"
-    ]
+        "skipLibCheck": false
+    }
 }


### PR DESCRIPTION
See #203 and #219
TODO: use updated acebase-core (see https://github.com/appy-one/acebase-core/pull/40)