### PR TITLE
Fix (invisible) tsc compile errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "acebase-core": "^1.26.1",
+        "acebase-core": "^1.26.2",
         "unidecode": "^0.1.8"
       },
       "devDependencies": {
@@ -38,7 +38,7 @@
         "jasmine": "^3.7.0",
         "terser": "^5.15.0",
         "tsc-esm-fix": "^2.20.5",
-        "typescript": "^4.7.4"
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/acebase-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.1.tgz",
-      "integrity": "sha512-n7iAAMAgO9+WQfYY6Gp+No74iphFfuaP+A/jCw9q8129ebL3KBR41cYykblxUz6Z1KyniQgbYAIptL5IhYeyYw==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.2.tgz",
+      "integrity": "sha512-Pg/eAq48H3aqyIYmwQEEMNX42UQXjNUDydAbT8UOmC1Q90X2j/U3M1yrTLT6i6fkOIdTT1iIrR8UqMxAvyucbw==",
       "optionalDependencies": {
         "rxjs": ">= 5.x <= 7.x"
       }
@@ -4130,16 +4130,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/umd": {
@@ -4734,9 +4734,9 @@
       }
     },
     "acebase-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.1.tgz",
-      "integrity": "sha512-n7iAAMAgO9+WQfYY6Gp+No74iphFfuaP+A/jCw9q8129ebL3KBR41cYykblxUz6Z1KyniQgbYAIptL5IhYeyYw==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.2.tgz",
+      "integrity": "sha512-Pg/eAq48H3aqyIYmwQEEMNX42UQXjNUDydAbT8UOmC1Q90X2j/U3M1yrTLT6i6fkOIdTT1iIrR8UqMxAvyucbw==",
       "requires": {
         "rxjs": ">= 5.x <= 7.x"
       }
@@ -7528,9 +7528,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "umd": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "author": "Ewout Stortenbeker <me@appy.one> (http://appy.one)",
   "license": "MIT",
   "dependencies": {
-    "acebase-core": "^1.26.1",
+    "acebase-core": "^1.26.2",
     "unidecode": "^0.1.8"
   },
   "devDependencies": {
@@ -107,7 +107,7 @@
     "jasmine": "^3.7.0",
     "terser": "^5.15.0",
     "tsc-esm-fix": "^2.20.5",
-    "typescript": "^4.7.4"
+    "typescript": "^5.0.4"
   },
   "funding": [
     {

--- a/src/data-index/data-index.ts
+++ b/src/data-index/data-index.ts
@@ -1030,7 +1030,7 @@ export class DataIndex {
             : DataIndex.STATE.BUILD;
         this._buildError = null;
         const path = this.path;
-        const wildcardNames = path.match(/\*|\$[a-z0-9_]+/gi) || [];
+        const wildcardNames = Array.from(path.match(/\*|\$[a-z0-9_]+/gi) ?? []);
         // const hasWildcards = wildcardNames.length > 0;
         const wildcardsPattern = '^' + path.replace(/\*|\$[a-z0-9_]+/gi, '([a-z0-9_]+)') + '/';
         const wildcardRE = new RegExp(wildcardsPattern, 'i');

--- a/src/data-index/geo-index.ts
+++ b/src/data-index/geo-index.ts
@@ -213,10 +213,10 @@ export class GeoIndex extends DataIndex {
             this.storage.debug.warn('Not implemented: query options for geo indexes are ignored');
         }
         if (op === 'geo:nearby') {
-            if (val === null || typeof val !== 'object' || !('lat' in val) || !('long' in val) || !('radius' in val)) {
-                throw new Error(`geo nearby query expects an object with lat, long and radius properties`);
+            if (val === null || typeof val !== 'object' || !('lat' in val) || !('long' in val) || !('radius' in val) || typeof val.lat !== 'number' || typeof val.long !== 'number' || typeof val.radius !== 'number') {
+                throw new Error(`geo nearby query expects an object with numeric lat, long and radius properties`);
             }
-            return this.nearby(val);
+            return this.nearby(val as { lat: number; long: number; radius: number });
         }
         else {
             throw new Error(`Geo indexes can only be queried with operators ${GeoIndex.validOperators.map(op => `"${op}"`).join(', ')}`);

--- a/src/node-info.ts
+++ b/src/node-info.ts
@@ -1,10 +1,10 @@
-import { getValueTypeName } from './node-value-types';
+import { NodeValueType, getValueTypeName } from './node-value-types';
 import { PathInfo } from 'acebase-core';
 import { NodeAddress } from './node-address';
 
 export class NodeInfo {
     path?: string;
-    type?: number;
+    type?: NodeValueType;
     index?: number;
     key?: string;
     exists?: boolean;

--- a/src/node-value-types.ts
+++ b/src/node-value-types.ts
@@ -1,6 +1,6 @@
 import { PathReference } from 'acebase-core';
 
-export const VALUE_TYPES = Object.freeze({
+const nodeValueTypes = {
     // Native types:
     OBJECT: 1,
     ARRAY: 2,
@@ -14,7 +14,9 @@ export const VALUE_TYPES = Object.freeze({
     REFERENCE: 9,        // Absolute or relative path to other node
     // Future:
     // DOCUMENT: 10,     // JSON/XML documents that are contained entirely within the stored node
-});
+} as const;
+export type NodeValueType = typeof nodeValueTypes[keyof typeof nodeValueTypes];
+export const VALUE_TYPES = nodeValueTypes as Record<keyof typeof nodeValueTypes, NodeValueType>;
 
 export function getValueTypeName(valueType: number) {
     switch (valueType) {

--- a/src/storage/custom/local-storage/transaction.ts
+++ b/src/storage/custom/local-storage/transaction.ts
@@ -40,7 +40,7 @@ export class LocalStorageTransaction extends CustomStorageTransaction {
     async childrenOf(path: string,
         include: { metadata?: boolean; value?: boolean },
         checkCallback: (path: string) => boolean,
-        addCallback: (path: string, node: ICustomStorageNodeMetaData | ICustomStorageNode) => boolean,
+        addCallback: (path: string, node?: ICustomStorageNodeMetaData | ICustomStorageNode) => boolean,
     ) {
         // Streams all child paths
         // Cannot query localStorage, so loop through all stored keys to find children
@@ -64,7 +64,7 @@ export class LocalStorageTransaction extends CustomStorageTransaction {
     async descendantsOf(path: string,
         include: { metadata?: boolean; value?: boolean },
         checkCallback: (path: string) => boolean,
-        addCallback: (path: string, node: ICustomStorageNodeMetaData | ICustomStorageNode) => boolean,
+        addCallback: (path: string, node?: ICustomStorageNodeMetaData | ICustomStorageNode) => boolean,
     ) {
         // Streams all descendant paths
         // Cannot query localStorage, so loop through all stored keys to find descendants

--- a/src/storage/mssql/index.ts
+++ b/src/storage/mssql/index.ts
@@ -1,7 +1,7 @@
 import { ID, PathReference, PathInfo, ascii85, ColorStyle } from 'acebase-core';
 import { Storage, StorageEnv, StorageSettings } from '..';
 import { NodeInfo } from '../../node-info';
-import { VALUE_TYPES } from '../../node-value-types';
+import { NodeValueType, VALUE_TYPES } from '../../node-value-types';
 import { NodeNotFoundError, NodeRevisionError } from '../../node-errors';
 import { pfs } from '../../promise-fs';
 import { NodeAddress } from '../../node-address';
@@ -447,7 +447,7 @@ export class MSSQLStorage extends Storage {
     }
 
     _getTypeFromStoredValue(val: unknown) {
-        let type: number;
+        let type: NodeValueType;
         if (typeof val === 'string') {
             type = VALUE_TYPES.STRING;
         }
@@ -783,7 +783,7 @@ export class MSSQLStorage extends Storage {
         } = {},
     ) {
         // return generator
-        type CallbackFunction = (child: MSSQLNodeInfo) => boolean;
+        type CallbackFunction = (child: MSSQLNodeInfo) => boolean | void | Promise<boolean | void>;
         let callback: CallbackFunction;
         const generator = {
             /**

--- a/src/storage/sqlite/index.ts
+++ b/src/storage/sqlite/index.ts
@@ -701,7 +701,7 @@ export class SQLiteStorage extends Storage {
         } = {},
     ) {
         // return generator
-        type CallbackFunction = (child: SQLiteNodeInfo) => boolean;
+        type CallbackFunction = (child: SQLiteNodeInfo) => boolean | void | Promise<boolean | void>;
         let callback: CallbackFunction; //, resolve, reject;
         const generator = {
             /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "declarationMap": true,
         "declarationDir": "./dist/types",
         "resolveJsonModule": true,
-        "skipLibCheck": true
+        "skipLibCheck": false
     },
     "include": ["src/**/*"],
     "exclude": [


### PR DESCRIPTION
When using AceBase in an external project using `"skipLibraryCheck": false` (default) in its _tsconfig.json_, it will yield compile errors that are not shown when compiling AceBase itself with `tsc`. Why there are no TypeScript errors should be investigated further. See #220