### PR TITLE
Fix: Socket IPC preventing process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2218,6 +2218,8 @@ AceBase supports running in multiple processes by using interprocess communicati
 
 If you are using pm2 to run your app in a cluster, or run your app in a cloud-based cluster (eg Kubernetes, Docker Swarm), AceBase instances will need some other way to communicate with eachother. This is now possible using an AceBase IPC Server, which allows fast communication using websockets. See [AceBase IPC Server](https://github.com/appy-one/acebase-ipc-server) for more info!
 
+**NEW** (v1.28.0): AceBase now supports an IPC mode that enables isolated processes on a single machine to access the same database simultaneously, without them having to setup an IPC cluster. By setting the storage `ipc` setting to `'socket'`, AceBase will launch (or connect to) a dedicated service process that communicates through very fast in-memory Unix sockets, or named pipes on Windows. The service will automatically shut down again once the database is not being accessed by any running process anymore. This will become the default IPC setting in the future.
+
 ## CommonJS and ESM packages
 The TypeScript sources are compiled to both CommonJS and ESM module systems. The sources loaded depend on whether you `import` or `require` acebase:
 | Statement                                  | Module system | Target |

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@types/jasmine": "^3.7.4",
-        "@types/node": "^14.14.37",
+        "@types/node": "^18.16.3",
         "@types/ws": "^8.2.2",
         "@typescript-eslint/eslint-plugin": "^5.30.6",
         "@typescript-eslint/parser": "^5.30.6",
@@ -308,9 +308,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -4600,9 +4600,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^3.7.4",
-    "@types/node": "^14.14.37",
+    "@types/node": "^18.16.3",
     "@types/ws": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
     "@typescript-eslint/parser": "^5.30.6",

--- a/src/ipc/index.ts
+++ b/src/ipc/index.ts
@@ -1,7 +1,7 @@
 import { AceBaseIPCPeer, IHelloMessage, IMessage } from './ipc';
 import { Storage } from '../storage';
 import * as Cluster from 'cluster';
-const cluster: typeof Cluster = (Cluster as any).default ?? Cluster; // ESM and CJS compatible approach
+const cluster = Cluster.default ?? Cluster as any as typeof Cluster.default; // ESM and CJS compatible approach
 export { RemoteIPCPeer, RemoteIPCServerConfig } from './remote';
 export { IPCSocketPeer, NetIPCServer } from './socket';
 

--- a/src/ipc/service/shared.ts
+++ b/src/ipc/service/shared.ts
@@ -1,7 +1,18 @@
+import { createHash } from 'crypto';
+
 export function getSocketPath(filePath: string) {
-    return process.platform ==='win32'
+    let path = process.platform ==='win32'
         ? `\\\\.\\pipe\\${filePath.replace(/^\//, '').replace(/\//g, '-')}`
         : `${filePath}.sock`;
+    const maxLength = process.platform ==='win32' ? 256 : 108;
+    if (path.length > maxLength) {
+        // Use hash of filepath instead
+        const hash = createHash('sha256').update(path).digest('hex');
+        path = process.platform ==='win32'
+            ? `\\\\.\\pipe\\${hash}`
+            : `${hash}.sock`;
+    }
+    return path;
 }
 
 // export const MSG_DELIMITER = String.fromCharCode(0) + String.fromCharCode(1) + String.fromCharCode(3) + String.fromCharCode(5) + String.fromCharCode(0);

--- a/src/ipc/service/start.ts
+++ b/src/ipc/service/start.ts
@@ -1,10 +1,23 @@
 import { startServer } from '.';
+import { type AceBaseLocalSettings } from '../../';
 
 (async () => {
     try {
         const dbFile = process.argv[2]; // full path to db storage file, eg '/home/ewout/project/db.acebase/data.db'
-        await startServer(dbFile, (code) => {
-            process.exit(code);
+        const settings = process.argv.slice(3).reduce((settings, arg, i, args) => {
+            switch (arg.toLowerCase()) {
+                case '--loglevel': settings.logLevel = args[i + 1] as AceBaseLocalSettings['logLevel']; break;
+                case '--maxidletime': settings.maxIdleTime = parseInt(args[i + 1]); break;
+            }
+            return settings;
+        }, { logLevel: 'log' as AceBaseLocalSettings['logLevel'], maxIdleTime: 5000 });
+
+        await startServer(dbFile, {
+            logLevel: settings.logLevel,
+            maxIdleTime: settings.maxIdleTime,
+            exit: (code) => {
+                process.exit(code);
+            },
         });
     }
     catch (err) {

--- a/src/test/bulk-import.spec.ts
+++ b/src/test/bulk-import.spec.ts
@@ -3,7 +3,7 @@ import { createTempDB } from './tempdb';
 import { ID } from 'acebase-core';
 
 // This test takes at least an hour on a fast system, enable only if you have time
-const LONG_RUNNING_TEST_ENABLED = false;
+const LONG_RUNNING_TEST_ENABLED = process.env.LONG_RUNNING_TESTS === 'true';
 
 describe('bulk import', () => {
     let db: AceBase, removeDB: () => Promise<void>;


### PR DESCRIPTION
This fixes a process not being able to exit because the socket IPC was keeping references to `stdout` and `stderr`. It also adds some command level settings and documentation!