### PR TITLE
Feature: "warn only" schema definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "acebase-core": "^1.26.3",
+        "acebase-core": "^1.27.0",
         "unidecode": "^0.1.8"
       },
       "devDependencies": {
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/acebase-core": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.3.tgz",
-      "integrity": "sha512-djcJdQhC/q7HA89mtxT4QuISzTKy6EB5RYfo2jveUQGW48KLxbmgBNvI+G6PZ2A/D4C63HOOXe7hIDHtyC/zAA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.27.1.tgz",
+      "integrity": "sha512-+yfjyzSWKLIFNk7PdpER3zK2J8b1C6mxVgnHGM5cjimO244OqDR4IvZ7wAfM88oWqK8AnZ0WhbgVl4xoWsfrhA==",
       "optionalDependencies": {
         "rxjs": ">= 5.x <= 7.x"
       }
@@ -4572,9 +4572,9 @@
       }
     },
     "acebase-core": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.3.tgz",
-      "integrity": "sha512-djcJdQhC/q7HA89mtxT4QuISzTKy6EB5RYfo2jveUQGW48KLxbmgBNvI+G6PZ2A/D4C63HOOXe7hIDHtyC/zAA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.27.1.tgz",
+      "integrity": "sha512-+yfjyzSWKLIFNk7PdpER3zK2J8b1C6mxVgnHGM5cjimO244OqDR4IvZ7wAfM88oWqK8AnZ0WhbgVl4xoWsfrhA==",
       "requires": {
         "rxjs": ">= 5.x <= 7.x"
       }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "author": "Ewout Stortenbeker <me@appy.one> (http://appy.one)",
   "license": "MIT",
   "dependencies": {
-    "acebase-core": "^1.26.3",
+    "acebase-core": "^1.27.1",
     "unidecode": "^0.1.8"
   },
   "devDependencies": {

--- a/src/api-local.ts
+++ b/src/api-local.ts
@@ -340,8 +340,8 @@ export class LocalApi extends Api {
         return this.storage.importNode(path, read, options);
     }
 
-    async setSchema(path: string, schema: Record<string, any> | string) {
-        return this.storage.setSchema(path, schema);
+    async setSchema(path: string, schema: Record<string, any> | string, warnOnly = false) {
+        return this.storage.setSchema(path, schema, warnOnly);
     }
 
     async getSchema(path: string) {

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -2204,7 +2204,7 @@ export class Storage extends SimpleEventEmitter {
      * @param path target path to enforce the schema on, can include wildcards. Eg: 'users/*\/posts/*' or 'users/$uid/posts/$postid'
      * @param schema schema type definitions. When null value is passed, a previously set schema is removed.
      */
-    setSchema(path: string, schema: string|object) {
+    setSchema(path: string, schema: string|object, warnOnly = false) {
         if (typeof schema === 'undefined') {
             throw new TypeError('schema argument must be given');
         }
@@ -2215,7 +2215,10 @@ export class Storage extends SimpleEventEmitter {
             return;
         }
         // Parse schema, add or update it
-        const definition = new SchemaDefinition(schema);
+        const definition = new SchemaDefinition(schema, {
+            warnOnly,
+            warnCallback: (message: string) => this.debug.warn(message),
+        });
         const item = this._schemas.find(s => s.path === path);
         if (item) {
             item.schema = definition;

--- a/src/test/schema.spec.ts
+++ b/src/test/schema.spec.ts
@@ -209,6 +209,235 @@ describe('schema', () => {
 
     });
 
+    it('issues warnings only', async () => {
+
+        // Try using string type definitions
+        const clientSchema1 = {
+            name: 'string',
+            url: 'string',
+            email: 'string',
+            'contacts?': {
+                '*': {
+                    type: 'string',
+                    name: 'string',
+                    email: 'string',
+                    telephone: 'string',
+                },
+            },
+            'addresses?': {
+                '*': {
+                    type: '"postal"|"visit"',
+                    street: 'string',
+                    nr: 'number',
+                    city: 'string',
+                    'state?': 'string',
+                    country: '"nl"|"be"|"de"|"fr"',
+                },
+            },
+        };
+
+        expect(() => db.schema.set('clients/*', clientSchema1, true)).not.toThrow();
+
+        // Test if we can add client without contacts and addresses
+        let result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: '' }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test without email
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '' }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with wrong email data type
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: 35 }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with invalid property
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: '', wrong: 'not allowed' }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with wrong contact
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: '', contacts: 'none' }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with empty contacts
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: '', contacts: { } }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test with wrong contact item data type
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: '', contacts: { contact1: 'wrong contact' } }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with ok contact item
+        result = await db.schema.check('clients/client1', { name: 'Ewout', url: '', email: '', contacts: { contact1: { type: 'sales', name: 'John', email: '', telephone: '' } } }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test wrong contact item on target path
+        result = await db.schema.check('clients/client1/contacts/contact1', 'wrong contact', false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with ok contact item on target path
+        result = await db.schema.check('clients/client1/contacts/contact1', { type: 'sales', name: 'John', email: '', telephone: '' }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test updating a single property
+        result = await db.schema.check('clients/client1', { name: 'John' }, true);
+        expect(result).toEqual({ ok: true });
+
+        // Test removing a mandatory property
+        result = await db.schema.check('clients/client1', { name: null }, true);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test removing an optional property
+        result = await db.schema.check('clients/client1', { addresses: null }, true);
+        expect(result).toEqual({ ok: true });
+
+        // Test removing an unknown property
+        result = await db.schema.check('clients/client1', { unknown: null }, true);
+        expect(result).toEqual({ ok: true });
+
+        // Test updating a higher path that does not have a schema set (#217)
+        result = await db.schema.check('', { test: 'Test' }, true);
+        expect(result).toEqual({ ok: true });
+
+        // Try using classnames & regular expressions
+        const emailRegex = /[a-z.\-_]+@(?:[a-z\-_]+\.){1,}[a-z]{2,}$/i;
+        const clientSchema2 = {
+            name: String,
+            url: /^https:\/\//,
+            email: emailRegex,
+            'contacts?': {
+                '*': {
+                    type: String,
+                    name: String,
+                    email: emailRegex,
+                    telephone: /^\+[0-9\-]{10,}$/,
+                },
+            },
+            'addresses?': {
+                '*': {
+                    type: '"postal"|"visit"',
+                    street: String,
+                    nr: Number,
+                    city: String,
+                    'state?': String,
+                    country: /^[A-Z]{2}$/,
+                },
+            },
+        };
+
+        // Overwrite previous schema
+        expect(() => db.schema.set('clients/*', clientSchema2, true)).not.toThrow();
+
+        // Test valid input
+        result = await db.schema.check('clients/client1', { name: 'My client', url: 'https://client.com', email: 'info@client.com' }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test with empty email
+        result = await db.schema.check('clients/client1/email', '', false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with invalid email
+        result = await db.schema.check('clients/client1/email', 'not valid @address.com', false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test with valid email
+        result = await db.schema.check('clients/client1/email', 'test@address.com', false);
+        expect(result).toEqual({ ok: true });
+
+        // Test valid address
+        result = await db.schema.check('clients/client1/addresses/address1', { type: 'visit', street: 'Main', nr: 253, city: 'Capital', country: 'NL' }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test invalid address type
+        result = await db.schema.check('clients/client1/addresses/address1', { type: 'invalid', street: 'Main', nr: 253, city: 'Capital', country: 'NL' }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test invalid country (lowercase)
+        result = await db.schema.check('clients/client1/addresses/address1', { type: 'postal', street: 'Main', nr: 253, city: 'Capital', country: 'nl' }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test updating property to valid value
+        result = await db.schema.check('clients/client1/addresses/address1', { country: 'NL' }, true);
+        expect(result).toEqual({ ok: true });
+
+        // Test updating property to invalid value
+        result = await db.schema.check('clients/client1/addresses/address1', { country: 'nl' }, true);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test updating target to valid value
+        result = await db.schema.check('clients/client1/addresses/address1/country', 'NL', true);
+        expect(result).toEqual({ ok: true });
+
+        // Test updating target to invalid value
+        result = await db.schema.check('clients/client1/addresses/address1/country', 'nl', true);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Create new schema to test static values
+        const staticValuesSchema = {
+            'bool?': true,
+            'int?': 35,
+            'float?': 101.101,
+        };
+
+        expect(() => db.schema.set('static', staticValuesSchema, true)).not.toThrow();
+
+        // Test valid boolean value:
+        result = await db.schema.check('static', { bool: true }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test invalid boolean value:
+        result = await db.schema.check('static', { bool: false }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test valid int value:
+        result = await db.schema.check('static', { int: 35 }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test invalid int value:
+        result = await db.schema.check('static', { int: 2323 }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+
+        // Test valid float value:
+        result = await db.schema.check('static', { float: 101.101 }, false);
+        expect(result).toEqual({ ok: true });
+
+        // Test invalid float value:
+        result = await db.schema.check('static', { float: 897.452 }, false);
+        expect(result.ok).toBeTrue();
+        expect(result.reason).not.toBeUndefined();
+        expect(result.warning).not.toBeUndefined();
+    });
+
+
     it('type Object must allow any property', async() => {
         const schema = 'Object';
         expect(() => db.schema.set('generic-object', schema)).not.toThrow();


### PR DESCRIPTION
This enables one to introduce schema definitions to an existing database, but logs warnings instead of denying writes not conforming to the schema.