### PR TITLE
Fix `target` of `mutations` events on wildcard paths

### DIFF
--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1165,7 +1165,8 @@ export class Storage extends SimpleEventEmitter {
                     // Send 1 batch with all mutations
                     // const oldValues = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(mutation.path.slice(sub.subscriptionPath.length)), val: m.oldValue })); // batch.reduce((obj, mutation) => (obj[mutation.path.slice(sub.subscriptionPath.length).replace(/^\//, '') || '.'] = mutation.oldValue, obj), {});
                     // const newValues = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(mutation.path.slice(sub.subscriptionPath.length)), val: m.newValue })) //batch.reduce((obj, mutation) => (obj[mutation.path.slice(sub.subscriptionPath.length).replace(/^\//, '') || '.'] = mutation.newValue, obj), {});
-                    const values = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(m.path.slice(sub.subscriptionPath.length)), prev: m.oldValue, val: m.newValue }));
+                    const subscriptionPathKeys = PathInfo.getPathKeys(sub.subscriptionPath);
+                    const values = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(m.path).slice(subscriptionPathKeys.length), prev: m.oldValue, val: m.newValue }));
                     this.subscriptions.trigger(sub.type, sub.subscriptionPath, sub.subscriptionPath, null, values, options.context);
                 }
             });

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1135,39 +1135,70 @@ export class Storage extends SimpleEventEmitter {
             mutationEvents.forEach(sub => {
                 // Get the target data this subscription is interested in
                 let currentPath = topEventPath;
-                const trailPath = sub.eventPath.slice(currentPath.length).replace(/^\//, '');
-                const trailKeys = PathInfo.getPathKeys(trailPath);
+                // const trailPath = sub.eventPath.slice(currentPath.length).replace(/^\//, ''); // eventPath can contain vars and * ?
+                const trailKeys = PathInfo.getPathKeys(sub.eventPath).slice(PathInfo.getPathKeys(currentPath).length); //PathInfo.getPathKeys(trailPath);
+                
+                const events = [] as Array<{
+                    target: (string|number)[];
+                    vars: Array<{ name: string; value: string|number }>;
+                    oldValue: any;
+                    newValue: any; 
+                }>;
                 let oldValue = topEventData, newValue = newTopEventData;
-                while (trailKeys.length > 0) {
-                    const subKey = trailKeys.shift();
-                    currentPath = PathInfo.getChildPath(currentPath, subKey);
-                    const childValues = getChildValues(subKey, oldValue, newValue);
-                    oldValue = childValues.oldValue;
-                    newValue = childValues.newValue;
-                }
-
-                const batch = prepareMutationEvents(currentPath, oldValue, newValue);
-                if (batch.length === 0) {
-                    return;
-                }
-                const isNotifyEvent = sub.type.startsWith('notify_');
-                if (['mutated','notify_mutated'].includes(sub.type)) {
-                    // Send all mutations 1 by 1
-                    batch.forEach((mutation, index) => {
-                        const context = options.context; // const context = cloneObject(options.context);
-                        // context.acebase_mutated_event = { nr: index + 1, total: batch.length }; // Add context info about number of mutations
-                        const prevVal = isNotifyEvent ? null : mutation.oldValue;
-                        const newVal = isNotifyEvent ? null : mutation.newValue;
-                        this.subscriptions.trigger(sub.type, sub.subscriptionPath, mutation.path, prevVal, newVal, context);
-                    });
-                }
-                else if (['mutations','notify_mutations'].includes(sub.type)) {
-                    // Send 1 batch with all mutations
-                    // const oldValues = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(mutation.path.slice(sub.subscriptionPath.length)), val: m.oldValue })); // batch.reduce((obj, mutation) => (obj[mutation.path.slice(sub.subscriptionPath.length).replace(/^\//, '') || '.'] = mutation.oldValue, obj), {});
-                    // const newValues = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(mutation.path.slice(sub.subscriptionPath.length)), val: m.newValue })) //batch.reduce((obj, mutation) => (obj[mutation.path.slice(sub.subscriptionPath.length).replace(/^\//, '') || '.'] = mutation.newValue, obj), {});
-                    const subscriptionPathKeys = PathInfo.getPathKeys(sub.subscriptionPath);
-                    const values = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(m.path).slice(subscriptionPathKeys.length), prev: m.oldValue, val: m.newValue }));
-                    this.subscriptions.trigger(sub.type, sub.subscriptionPath, sub.subscriptionPath, null, values, options.context);
+                const processNextTrailKey = (target: typeof trailKeys, currentTarget: typeof trailKeys, oldValue: any, newValue: any, vars: Array<{ name: string; value: string|number }>) => {
+                    if (target.length === 0) {
+                        // Add it
+                        return events.push({ target: currentTarget, oldValue, newValue, vars })
+                    }
+                    const subKey = target[0];
+                    const keys = new Set<typeof subKey>();
+                    const isWildcardKey = typeof subKey === 'string' && (subKey === '*' || subKey.startsWith('$'));
+                    if (isWildcardKey) {
+                        // Recursive for each key in oldValue and newValue
+                        if (oldValue !== null && typeof oldValue === 'object') {
+                            Object.keys(oldValue).forEach(key => keys.add(key)); 
+                        }
+                        if (newValue !== null && typeof newValue === 'object') {
+                            Object.keys(newValue).forEach(key => keys.add(key)); 
+                        }
+                    }
+                    else {
+                        keys.add(subKey); // just one specific key
+                    }
+                    for (const key of keys) {
+                        const childValues = getChildValues(key, oldValue, newValue);
+                        oldValue = childValues.oldValue;
+                        newValue = childValues.newValue;
+                        processNextTrailKey(target.slice(1), currentTarget.concat(key), oldValue, newValue, isWildcardKey ? vars.concat({ name: subKey, value: key }) : vars);
+                    }
+                };
+                processNextTrailKey(trailKeys, [], oldValue, newValue, []);
+                for (const event of events) {
+                    const targetPath = PathInfo.get(currentPath).child(event.target).path;
+                    const batch = prepareMutationEvents(targetPath, event.oldValue, event.newValue);
+                    if (batch.length === 0) {
+                        continue;
+                    }
+                    const isNotifyEvent = sub.type.startsWith('notify_');
+                    if (['mutated','notify_mutated'].includes(sub.type)) {
+                        // Send all mutations 1 by 1
+                        batch.forEach((mutation, index) => {
+                            const context = options.context; // const context = cloneObject(options.context);
+                            // context.acebase_mutated_event = { nr: index + 1, total: batch.length }; // Add context info about number of mutations
+                            const prevVal = isNotifyEvent ? null : mutation.oldValue;
+                            const newVal = isNotifyEvent ? null : mutation.newValue;
+                            this.subscriptions.trigger(sub.type, sub.subscriptionPath, mutation.path, prevVal, newVal, context);
+                        });
+                    }
+                    else if (['mutations','notify_mutations'].includes(sub.type)) {
+                        // Send 1 batch with all mutations
+                        // const oldValues = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(mutation.path.slice(sub.subscriptionPath.length)), val: m.oldValue })); // batch.reduce((obj, mutation) => (obj[mutation.path.slice(sub.subscriptionPath.length).replace(/^\//, '') || '.'] = mutation.oldValue, obj), {});
+                        // const newValues = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(mutation.path.slice(sub.subscriptionPath.length)), val: m.newValue })) //batch.reduce((obj, mutation) => (obj[mutation.path.slice(sub.subscriptionPath.length).replace(/^\//, '') || '.'] = mutation.newValue, obj), {});
+                        const subscriptionPathKeys = PathInfo.getPathKeys(sub.subscriptionPath);
+                        const values = isNotifyEvent ? null : batch.map(m => ({ target: PathInfo.getPathKeys(m.path).slice(subscriptionPathKeys.length), prev: m.oldValue, val: m.newValue }));
+                        const dataPath = PathInfo.get(PathInfo.getPathKeys(targetPath).slice(0, subscriptionPathKeys.length)).path;
+                        this.subscriptions.trigger(sub.type, sub.subscriptionPath, dataPath, null, values, options.context);
+                    }
                 }
             });
         };


### PR DESCRIPTION
If `mutations` or `notify_mutations` are set on a path containing wildcards (* or named variables), the mutation's `target` is not being set correctly.

Example:
```js
db.ref('users/*/books').on('mutations', (mutations) => {
  mutations.forEach(snap => {
    const m = snap.val();
    const target = m.target;
    // if mutation is on `users/user1/books/book1/title`, target contains ['ooks', 'book1', 'title']
    // but target should be ['book1', 'title']
  });
});
```

TODO: `snap.ref.path` probably contains `users/*/books`, but should be `users/user1/books` in above example. Check this, fix it if true.