### PR TITLE
Add support for old Safari in webworker

### DIFF
--- a/src/ipc/browser.ts
+++ b/src/ipc/browser.ts
@@ -31,7 +31,7 @@ export class IPCPeer extends AceBaseIPCPeer {
         if (typeof BroadcastChannel !== 'undefined') {
             this.channel = new BroadcastChannel(`acebase:${storage.name}`);
         }
-        else {
+        else if (typeof localStorage !== 'undefined') {
             // Use localStorage as polyfill for Safari & iOS WebKit
             const listeners:MessageEventCallback[] = [null]; // first callback reserved for onmessage handler
             const notImplemented = () => { throw new Error('Not implemented'); };
@@ -81,6 +81,12 @@ export class IPCPeer extends AceBaseIPCPeer {
                 const message = Transport.deserialize(JSON.parse(event.newValue));
                 this.channel.dispatchEvent({ data: message } as MessageEvent);
             });
+        }
+        else {
+            // No localStorage either, this is probably an old browser running in a webworker
+            this.storage.debug.warn(`[BroadcastChannel] not supported`);
+            this.sendMessage = () => { /* No OP */};
+            return;
         }
 
         // Monitor incoming messages


### PR DESCRIPTION
Old Safari versions (up to iOS 15?) don't support BroadcastChannel, and when AceBase is runs in a webworker there is no localStorage to fallback to: disable browser IPC in this case.