### PR TITLE
Fix issue #239

### DIFF
--- a/src/btree/binary-tree.ts
+++ b/src/btree/binary-tree.ts
@@ -3011,7 +3011,7 @@ export class BinaryBPlusTree {
                 throw new DetailedError('small-ptrs-deprecated', 'small ptrs have deprecated, tree will have to be rebuilt');
             }
             const entryIndex = leaf.entries.findIndex(entry => _isEqual(key, entry.key));
-            if (!~entryIndex) { return; }
+            if (entryIndex < 0) { return; }
             if (this.info.isUnique || typeof recordPointer === 'undefined' || leaf.entries[entryIndex].totalValues === 1) {
                 leaf.entries.splice(entryIndex, 1);
             }
@@ -3020,7 +3020,7 @@ export class BinaryBPlusTree {
             }
             else {
                 const valueIndex = leaf.entries[entryIndex].values.findIndex(val => _compareBinary(val.recordPointer, recordPointer));
-                if (!~valueIndex) { return; }
+                if (valueIndex < 0) { return; }
                 leaf.entries[entryIndex].values.splice(valueIndex, 1);
             }
             if (leaf.parentNode && leaf.entries.length === 0) {

--- a/src/btree/binary-tree.ts
+++ b/src/btree/binary-tree.ts
@@ -1761,9 +1761,12 @@ export class BinaryBPlusTree {
         const results = [] as Array<{ key: NodeEntryKeyType, value: any, totalValues: number }>;
 
         // Get upperbound
-        const lastLeaf = await this._getLastLeaf();
-        if (!lastLeaf.parentNode && lastLeaf.entries.length === 0) {
-            // Empty single-leaf tree
+        let lastLeaf = await this._getLastLeaf();
+        while (lastLeaf.entries.length === 0 && lastLeaf.hasPrevious) {
+            lastLeaf = await lastLeaf.getPrevious();
+        }
+        if (lastLeaf.entries.length === 0) {
+            // Empty tree
             return [] as typeof results;
         }
         const lastEntry = lastLeaf.entries.slice(-1)[0];
@@ -1778,7 +1781,10 @@ export class BinaryBPlusTree {
         }
 
         // Get lowerbound
-        const firstLeaf = await this._getFirstLeaf();
+        let firstLeaf = await this._getFirstLeaf();
+        while (firstLeaf.entries.length === 0 && firstLeaf.hasNext) {
+            firstLeaf = await firstLeaf.getNext();
+        }
         const firstEntry = firstLeaf.entries[0];
         const firstKey = firstEntry.key;
 

--- a/src/storage/binary/test.spec.ts
+++ b/src/storage/binary/test.spec.ts
@@ -1,0 +1,38 @@
+import { AceBase } from '../..';
+import { createTempDB } from '../../test/tempdb';
+
+describe('issue', () => {
+    let db: AceBase, removeDB: () => Promise<void>;
+
+    beforeAll(async ()=> {
+        ({ db, removeDB } = await createTempDB({ config(options) {
+            options.logLevel = 'warn';
+        }}));
+    });
+    afterAll(async () => {
+        await removeDB();
+    });
+
+    it('#239', async () => {
+        // Created for issue #239 ("TypeError when trying to add new records after removing old ones")
+        const ref = db.ref('table');
+
+        // add "large" dataset to the database
+        const songIds1 = Array(110).fill(0).map((_value, index) => `id-${index}`);
+        await ref.update(songIds1.reduce((obj, songId) => {
+            obj[songId] = { playlistId: 'playlist1' };
+            return obj;
+        }, {} as any));
+
+        // remove all the added records with the query
+        await ref.query().filter('playlistId', '==', 'playlist1').remove();
+
+        // add new "small" dataset to the database -> error
+        const songIds2 = Array(10).fill(0).map((_value, index) => `id-${index}`);
+        await ref.update(songIds2.reduce((obj, songId) => {
+            obj[songId] = { playlistId: 'playlist1' };
+            return obj;
+        }, {} as any));
+
+    });
+});


### PR DESCRIPTION
This fixes the issue described in #239, where adding children to an empty tree causes issues because the binary tree leaf was left behind empty. This code changes the delete behaviour to rebuild the tree after a leaf has become empty and its parent node will be left without child entries