### PR TITLE
Drastically improve large node (re)writes

### DIFF
--- a/src/btree/binary-tree.ts
+++ b/src/btree/binary-tree.ts
@@ -3256,7 +3256,7 @@ export class BinaryBPlusTree {
         fillFactor?: number;
         /** whether free space for later node/leaf creation is kept or added. If `allocatedBytes` is not given (or 0), 10% free space will be used. Default is `true` */
         keepFreeSpace?: boolean;
-        /** whether to increase the max amount of node/leaf entries (usually rebuilding is needed because of growth, so this might be a good idea). Default is true, will increase max entries with 10% (until the max of 255 is reached) */
+        /** whether to increase the max amount of node/leaf entries (usually rebuilding is needed because of growth, so this might be a good idea). Default is true, will increase max entries with 50% (until the max of 255 is reached) */
         increaseMaxEntries?: boolean;
         /** optionally reserves free space for specified amount of new leaf entries (overrides the default of 10% growth, only applies if `allocatedBytes` is not specified or 0). Default is `0` */
         reserveSpaceForNewEntries?: number;
@@ -3313,19 +3313,19 @@ export class BinaryBPlusTree {
         const originalChunkSize = this._chunkSize;
         // this._chunkSize = 1024 * 1024; // Read 1MB at a time to speed up IO
 
-        options = options || {};
-        options.fillFactor = options.fillFactor || this.info.fillFactor || 95;
+        options = options ?? {};
+        options.fillFactor = options.fillFactor ?? this.info.fillFactor ?? 95;
         options.keepFreeSpace = options.keepFreeSpace !== false;
         options.increaseMaxEntries = options.increaseMaxEntries !== false;
-        options.treeStatistics = options.treeStatistics || { byteLength: 0, totalEntries: 0, totalValues: 0, totalLeafs: 0, depth: 0, entriesPerNode: 0 };
+        options.treeStatistics = options.treeStatistics ?? { byteLength: 0, totalEntries: 0, totalValues: 0, totalLeafs: 0, depth: 0, entriesPerNode: 0 };
         if (typeof options.allocatedBytes === 'number') {
             options.treeStatistics.byteLength = options.allocatedBytes;
         }
 
         let maxEntriesPerNode = this.info.entriesPerNode;
         if (options.increaseMaxEntries && maxEntriesPerNode < 255) {
-            // Increase nr of entries per node with 10%
-            maxEntriesPerNode = Math.min(255, Math.round(maxEntriesPerNode * 1.1));
+            // Increase nr of entries per node with 50%
+            maxEntriesPerNode = Math.min(255, Math.round(maxEntriesPerNode * 1.5));
         }
         options.treeStatistics.entriesPerNode = maxEntriesPerNode;
         // let entriesPerLeaf = Math.round(maxEntriesPerNode * (options.fillFactor / 100));

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -2414,12 +2414,31 @@ class NodeAllocation {
 
     get addresses(): StorageAddress[] {
         const addresses = [] as StorageAddress[];
-        this.ranges.forEach(range => {
+        for (const range of this.ranges) {
             for (let i = 0; i < range.length; i++) {
                 const address = new StorageAddress(range.pageNr, range.recordNr + i);
                 addresses.push(address);
             }
-        });
+        }
+        return addresses;
+    }
+    /**
+     * Gets individual record addresses from current allocation
+     * @param start index to start
+     * @param end index to stop (does not include this record)
+     */
+    getAddresses(start: number, end: number) {
+        const addresses = [] as StorageAddress[];
+        let nr = 0;
+        for (const range of this.ranges) {
+            for (let i = 0; i < range.length && nr < end; i++, nr++) {
+                if (nr >= start && nr < end) {
+                    const address = new StorageAddress(range.pageNr, range.recordNr + i);
+                    addresses.push(address);
+                }
+            }
+            if (nr >= end) { break; }
+        }
         return addresses;
     }
 
@@ -3056,7 +3075,7 @@ class NodeReader {
             if (this.recordInfo.hasKeyIndex) {
                 return createStreamFromBinaryTree();
             }
-            else if (this.recordInfo.allocation.addresses.length === 1) {
+            else if (this.recordInfo.allocation.totalAddresses === 1) {
                 // We have all data in memory (small record)
                 return createStreamFromLinearData(this.recordInfo.startData, true);
             }
@@ -3371,6 +3390,7 @@ class NodeReader {
         });
     }
 
+    // #allocatedAddresses = null as StorageAddress[] | null;
     async _treeDataWriter(binary: number[] | Buffer, index: number) {
         if (binary instanceof Array) {
             binary = Buffer.from(binary);
@@ -3386,7 +3406,11 @@ class NodeReader {
             nr: Math.floor((headerLength + index + length) / recordSize),
             offset: (headerLength + index + length) % recordSize,
         };
-        const writeRecords = this.recordInfo.allocation.addresses.slice(startRecord.nr, endRecord.nr + 1);
+        // if (!this.#allocatedAddresses) {
+        //     this.#allocatedAddresses = this.recordInfo.allocation.addresses;
+        // }
+        // const writeRecords = this.#allocatedAddresses.slice(startRecord.nr, endRecord.nr + 1);
+        const writeRecords = this.recordInfo.allocation.getAddresses(startRecord.nr, endRecord.nr + 1);
         const writeRanges = NodeAllocation.fromAdresses(writeRecords).ranges;
         const writes = [];
         let bOffset = 0;
@@ -3421,11 +3445,15 @@ class NodeReader {
             nr: Math.floor((headerLength + index + length) / recordSize),
             offset: (headerLength + index + length) % recordSize,
         };
-        const readRecords = this.recordInfo.allocation.addresses.slice(startRecord.nr, endRecord.nr + 1);
+        // if (!this.#allocatedAddresses) {
+        //     this.#allocatedAddresses = this.recordInfo.allocation.addresses;
+        // }
+        // const readRecords = this.#allocatedAddresses.slice(startRecord.nr, endRecord.nr + 1);
+        const readRecords = this.recordInfo.allocation.getAddresses(startRecord.nr, endRecord.nr + 1);
         if (readRecords.length === 0) {
             throw new Error(
                 `Attempt to read non-existing records of path "/${this.recordInfo.path}": ${startRecord.nr} to ${endRecord.nr + 1} ` +
-                `for index ${index} + ${length} bytes. Node has ${this.recordInfo.allocation.addresses.length} allocated records ` +
+                `for index ${index} + ${length} bytes. Node has ${this.recordInfo.allocation.totalAddresses} allocated records ` +
                 `in the following ranges: ` + this.recordInfo.allocation.toString()
             );
         }
@@ -3468,7 +3496,6 @@ class NodeReader {
         let view = new DataView(data.buffer);
         let offset = 1;
         const firstRange = new StorageAddressRange(this.address.pageNr, this.address.recordNr, 1);
-        /** @type {StorageAddressRange[]} */
         const ranges = [firstRange];
         const allocation = new NodeAllocation(ranges);
         let readingRecordIndex = 0;
@@ -3478,7 +3505,7 @@ class NodeReader {
             if (offset + 9 + 2 >= data.length) {
                 // Read more data (next record)
                 readingRecordIndex++;
-                const address = allocation.addresses[readingRecordIndex];
+                const [address] = allocation.getAddresses(readingRecordIndex, readingRecordIndex + 1);
                 const fileIndex = this.storage.getRecordFileIndex(address.pageNr, address.recordNr);
                 const moreData = new Uint8Array(bytesPerRecord);
                 await this.storage.readData(fileIndex, moreData.buffer);
@@ -4045,7 +4072,7 @@ async function _writeNode(storage: AceBaseStorage, path: string, value: any, loc
         // Create a B+tree
         const fillFactor =
             isArray || serialized.every(kvp => typeof kvp.key === 'string' && /^[0-9]+$/.test(kvp.key))
-                ? BINARY_TREE_FILL_FACTOR_50
+                ? BINARY_TREE_FILL_FACTOR_50 // TODO: Consider removing this, might be better performing now with 95% instead!
                 : BINARY_TREE_FILL_FACTOR_95;
 
         const treeBuilder = new BPlusTreeBuilder(true, fillFactor);

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -3390,7 +3390,6 @@ class NodeReader {
         });
     }
 
-    // #allocatedAddresses = null as StorageAddress[] | null;
     async _treeDataWriter(binary: number[] | Buffer, index: number) {
         if (binary instanceof Array) {
             binary = Buffer.from(binary);
@@ -3406,10 +3405,6 @@ class NodeReader {
             nr: Math.floor((headerLength + index + length) / recordSize),
             offset: (headerLength + index + length) % recordSize,
         };
-        // if (!this.#allocatedAddresses) {
-        //     this.#allocatedAddresses = this.recordInfo.allocation.addresses;
-        // }
-        // const writeRecords = this.#allocatedAddresses.slice(startRecord.nr, endRecord.nr + 1);
         const writeRecords = this.recordInfo.allocation.getAddresses(startRecord.nr, endRecord.nr + 1);
         const writeRanges = NodeAllocation.fromAdresses(writeRecords).ranges;
         const writes = [];
@@ -3445,10 +3440,6 @@ class NodeReader {
             nr: Math.floor((headerLength + index + length) / recordSize),
             offset: (headerLength + index + length) % recordSize,
         };
-        // if (!this.#allocatedAddresses) {
-        //     this.#allocatedAddresses = this.recordInfo.allocation.addresses;
-        // }
-        // const readRecords = this.#allocatedAddresses.slice(startRecord.nr, endRecord.nr + 1);
         const readRecords = this.recordInfo.allocation.getAddresses(startRecord.nr, endRecord.nr + 1);
         if (readRecords.length === 0) {
             throw new Error(


### PR DESCRIPTION
Dramatically increase the performance of (re)wiring large nodes spanning multiple allocation ranges (logical pages) by:
* Growing the max number of node entries faster (+50% instead of +10% per rebuild)
* Optimizing the code that requests individual record entries for allocated ranges