### PR TITLE
Add custom logger support

### DIFF
--- a/src/api-local.ts
+++ b/src/api-local.ts
@@ -1,7 +1,7 @@
 import { AceBaseBase, IStreamLike, Api, EventSubscriptionCallback,
     ReflectionType, IReflectionNodeInfo, IReflectionChildrenInfo,
     StreamReadFunction, StreamWriteFunction, TransactionLogFilter,
-    LoggingLevel, Query, QueryOptions } from 'acebase-core';
+    LoggingLevel, Query, QueryOptions, LoggerPlugin } from 'acebase-core';
 import { AceBaseStorage, AceBaseStorageSettings } from './storage/binary';
 import { SQLiteStorage, SQLiteStorageSettings } from './storage/sqlite';
 import { MSSQLStorage, MSSQLStorageSettings } from './storage/mssql';
@@ -19,12 +19,14 @@ export class LocalApi extends Api {
     public db: AceBaseBase;
     public storage: Storage;
     public logLevel: LoggingLevel;
+    public logger: LoggerPlugin;
 
     constructor(dbname = 'default', init: { db: AceBaseBase, settings: AceBaseLocalSettings }, readyCallback: () => any) {
         super();
         this.db = init.db;
+        this.logger = init.db.logger;
 
-        const storageEnv: StorageEnv = { logLevel: init.settings.logLevel };
+        const storageEnv: StorageEnv = { logLevel: init.settings.logLevel, logColors: init.settings.logColors, logger: init.settings.logger };
         if (typeof init.settings.storage === 'object') {
             // settings.storage.logLevel = settings.logLevel;
             if (SQLiteStorageSettings && (init.settings.storage instanceof SQLiteStorageSettings)) { //  || env.settings.storage.type === 'sqlite'

--- a/src/btree/binary-tree.spec.ts
+++ b/src/btree/binary-tree.spec.ts
@@ -12,7 +12,7 @@ describe('Unique Binary B+Tree', () => {
 
         const bytes = [] as number[];
         await tree.toBinary(true, BinaryWriter.forArray(bytes));
-        const binaryTree = new BinaryBPlusTree({ readFn: bytes, debug });
+        const binaryTree = new BinaryBPlusTree({ readFn: bytes, logger: debug });
         binaryTree.id = ID.generate(); // Assign an id to allow edits (is enforced by tree to make sure multiple concurrent edits to the same source are sync locked)
         binaryTree.autoGrow = AUTO_GROW;
         return binaryTree;
@@ -22,7 +22,7 @@ describe('Unique Binary B+Tree', () => {
         const bytes = [] as number[];
         const id = tree.id;
         await tree.rebuild(BinaryWriter.forArray(bytes), { fillFactor: FILL_FACTOR, keepFreeSpace: true, increaseMaxEntries: true });
-        tree = new BinaryBPlusTree({ readFn: bytes, debug });
+        tree = new BinaryBPlusTree({ readFn: bytes, logger: debug });
         tree.id = id;
         tree.autoGrow = AUTO_GROW;
         return tree;
@@ -282,7 +282,7 @@ describe('Unique Binary B+Tree', () => {
             });
 
             it('with BlacklistingSearchOperator', async () => {
-                const keysToBlacklist = keys.filter(key => Math.random() > 0.25); // blacklist ~75%
+                const keysToBlacklist = keys.filter(() => Math.random() > 0.25); // blacklist ~75%
                 const expectedKeys = keys.filter(key => !keysToBlacklist.includes(key));
 
                 const blacklisted = [] as BinaryBPlusTreeLeafEntry[];

--- a/src/data-index/array-index.ts
+++ b/src/data-index/array-index.ts
@@ -124,7 +124,7 @@ export class ArrayIndex extends DataIndex {
             throw new Error(`Array indexes can only be queried with operators ${ArrayIndex.validOperators.map(op => `"${op}"`).join(', ')}`);
         }
         if (options) {
-            this.storage.debug.warn('Not implemented: query options for array indexes are ignored');
+            this.logger.warn('Not implemented: query options for array indexes are ignored');
         }
 
         // Check cache
@@ -177,7 +177,7 @@ export class ArrayIndex extends DataIndex {
                 if (counts[0].count === 0) {
                     stats.stop(0);
 
-                    this.storage.debug.log(`Value "${counts[0].value}" not found in index, 0 results for query ${op} ${val}`);
+                    this.logger.info(`Value "${counts[0].value}" not found in index, 0 results for query ${op} ${val}`);
                     results = new IndexQueryResults(0);
                     results.filterKey = this.key;
                     results.stats = stats;

--- a/src/data-index/fulltext-index.ts
+++ b/src/data-index/fulltext-index.ts
@@ -372,7 +372,7 @@ export class FullTextIndex extends DataIndex {
         this.config = options.config || {};
         if (this.config.localeKey) {
             // localeKey is supported by all indexes now
-            storage.debug.warn(`fulltext index config option "localeKey" has been deprecated, as it is now supported for all indexes. Move the setting to the global index settings`);
+            this.logger.warn(`fulltext index config option "localeKey" has been deprecated, as it is now supported for all indexes. Move the setting to the global index settings`);
             this.textLocaleKey = this.config.localeKey; // Do use it now
         }
     }
@@ -562,7 +562,7 @@ export class FullTextIndex extends DataIndex {
                 const locale = env.locale || this.textLocale;
                 const textInfo = this.getTextInfo(text, locale);
                 if (textInfo.words.size === 0) {
-                    this.storage.debug.warn(`No words found in "${typeof text === 'string' && text.length > 50 ? text.slice(0, 50) + '...' : text}" to fulltext index "${env.path}"`);
+                    this.logger.warn(`No words found in "${typeof text === 'string' && text.length > 50 ? text.slice(0, 50) + '...' : text}" to fulltext index "${env.path}"`);
                 }
 
                 // const revLookupKey = super._getRevLookupKey(env.path);
@@ -851,7 +851,7 @@ export class FullTextIndex extends DataIndex {
         if (counts[0].count === 0) {
             stats.stop(0);
 
-            this.storage.debug.log(`Word "${counts[0].word}" not found in index, 0 results for query ${op} "${val}"`);
+            this.logger.info(`Word "${counts[0].word}" not found in index, 0 results for query ${op} "${val}"`);
             results = new IndexQueryResults(0);
             results.filterKey = this.key;
             results.stats = stats;
@@ -899,7 +899,7 @@ export class FullTextIndex extends DataIndex {
             const t1 = Date.now();
             const fr = await queryWord(word, results);
             const t2 = Date.now();
-            this.storage.debug.log(`fulltext search for "${word}" took ${t2-t1}ms`);
+            this.logger.info(`fulltext search for "${word}" took ${t2-t1}ms`);
             resultsPerWord[words.indexOf(word)] = fr;
             results = fr;
             wordIndex++;

--- a/src/data-index/geo-index.ts
+++ b/src/data-index/geo-index.ts
@@ -156,11 +156,11 @@ export class GeoIndex extends DataIndex {
         return super.build({
             addCallback: (add, obj: { lat: number; long: number; }, recordPointer, metadata) => {
                 if (typeof obj !== 'object') {
-                    this.storage.debug.warn(`GeoIndex cannot index location because value "${obj}" is not an object`);
+                    this.logger.warn(`GeoIndex cannot index location because value "${obj}" is not an object`);
                     return;
                 }
                 if (typeof obj.lat !== 'number' || typeof obj.long !== 'number') {
-                    this.storage.debug.warn(`GeoIndex cannot index location because lat (${obj.lat}) or long (${obj.long}) are invalid`);
+                    this.logger.warn(`GeoIndex cannot index location because lat (${obj.lat}) or long (${obj.long}) are invalid`);
                     return;
                 }
                 const geohash = _getGeoHash(obj);
@@ -210,7 +210,7 @@ export class GeoIndex extends DataIndex {
             throw new Error(`Not implemented: Can't query geo index with blacklisting operator yet`);
         }
         if (options) {
-            this.storage.debug.warn('Not implemented: query options for geo indexes are ignored');
+            this.logger.warn('Not implemented: query options for geo indexes are ignored');
         }
         if (op === 'geo:nearby') {
             if (val === null || typeof val !== 'object' || !('lat' in val) || !('long' in val) || !('radius' in val) || typeof val.lat !== 'number' || typeof val.long !== 'number' || typeof val.radius !== 'number') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ export {
     PartialArray,
 } from 'acebase-core';
 
+import { AceBase } from './acebase-local';
+export default AceBase; // Use AceBase as default export, allows: `import AceBase from 'acebase'`
+
 export {
     AceBase,
     AceBaseLocalSettings,

--- a/src/ipc/browser.ts
+++ b/src/ipc/browser.ts
@@ -84,7 +84,7 @@ export class IPCPeer extends AceBaseIPCPeer {
         }
         else {
             // No localStorage either, this is probably an old browser running in a webworker
-            this.storage.debug.warn(`[BroadcastChannel] not supported`);
+            this.logger.warn(`[BroadcastChannel] not supported`);
             this.sendMessage = () => { /* No OP */};
             return;
         }
@@ -98,22 +98,22 @@ export class IPCPeer extends AceBaseIPCPeer {
                 return;
             }
 
-            storage.debug.verbose(`[BroadcastChannel] received: `, message);
+            this.logger.trace(`[BroadcastChannel] received: `, message);
 
             if (message.type === 'hello' && message.from < this.masterPeerId) {
                 // This peer was created before other peer we thought was the master
                 this.masterPeerId = message.from;
-                storage.debug.log(`[BroadcastChannel] Tab ${this.masterPeerId} is the master.`);
+                this.logger.info(`[BroadcastChannel] Tab ${this.masterPeerId} is the master.`);
             }
             else if (message.type === 'bye' && message.from === this.masterPeerId) {
                 // The master tab is leaving
-                storage.debug.log(`[BroadcastChannel] Master tab ${this.masterPeerId} is leaving`);
+                this.logger.info(`[BroadcastChannel] Master tab ${this.masterPeerId} is leaving`);
 
                 // Elect new master
                 const allPeerIds = this.peers.map(peer => peer.id).concat(this.id).filter(id => id !== this.masterPeerId); // All peers, including us, excluding the leaving master peer
                 this.masterPeerId = allPeerIds.sort()[0];
 
-                storage.debug.log(`[BroadcastChannel] ${this.masterPeerId === this.id ? 'We are' : `tab ${this.masterPeerId} is`} the new master. Requesting ${this._locks.length} locks (${this._locks.filter(r => !r.granted).length} pending)`);
+                this.logger.info(`[BroadcastChannel] ${this.masterPeerId === this.id ? 'We are' : `tab ${this.masterPeerId} is`} the new master. Requesting ${this._locks.length} locks (${this._locks.filter(r => !r.granted).length} pending)`);
 
                 // Let the new master take over any locks and lock requests.
                 const requests =  this._locks.splice(0); // Copy and clear current lock requests before granted locks are requested again.
@@ -158,7 +158,7 @@ export class IPCPeer extends AceBaseIPCPeer {
     }
 
     sendMessage(message: IMessage) {
-        this.storage.debug.verbose(`[BroadcastChannel] sending: `, message);
+        this.logger.trace(`[BroadcastChannel] sending: `, message);
         this.channel.postMessage(message);
     }
 

--- a/src/ipc/index.ts
+++ b/src/ipc/index.ts
@@ -56,7 +56,7 @@ export class IPCPeer extends AceBaseIPCPeer {
                 // A new worker is started
                 // Do not add yet, wait for "hello" message - a forked process might not use the same db
                 bindEventHandler(worker, 'error', err => {
-                    storage.debug.error(`Caught worker error:`, err);
+                    this.logger.error(`Caught worker error:`, err);
                 });
             });
 

--- a/src/ipc/remote.ts
+++ b/src/ipc/remote.ts
@@ -114,7 +114,7 @@ export class RemoteIPCPeer extends AceBaseIPCPeer {
         this.masterPeerId = masterPeerId;
 
         this.connect().catch(err => {
-            storage.debug.error(err.message);
+            this.logger.error(err.message);
             this.exit();
         });
     }
@@ -171,7 +171,7 @@ export class RemoteIPCPeer extends AceBaseIPCPeer {
                     }
                     else if (typeof options?.maxRetries === 'undefined' || typeof options?.maxRetries === 'number' && options?.maxRetries > 0) {
                         const retryMs = 1000; // ms
-                        this.storage.debug.error(`Unable to connect to remote IPC server (${event.message}). Trying again in ${retryMs}ms`);
+                        this.logger.error(`Unable to connect to remote IPC server (${event.message}). Trying again in ${retryMs}ms`);
                         const retryOptions:{ maxRetries?: number } = {};
                         if (typeof typeof options?.maxRetries === 'number') { retryOptions.maxRetries = options.maxRetries-1; }
                         const timeout = setTimeout(() => { this.connect(retryOptions); }, retryMs);
@@ -209,7 +209,7 @@ export class RemoteIPCPeer extends AceBaseIPCPeer {
                 // Disconnected. Try reconnecting immediately
                 if (!connected) { return; } // We weren't connected yet. Don't reconnect here, retries will be executed automatically
                 if (this._exiting) { return; }
-                this.storage.debug.error(`Connection to remote IPC server was lost. Trying to reconnect`);
+                this.logger.error(`Connection to remote IPC server was lost. Trying to reconnect`);
                 clearInterval(pingInterval);
                 this.storage.invalidateCache?.(true, '', true, 'ipc_ws_disconnect'); // Make sure the entire cache is invalidated (AceBase storage has such cache)
                 this.connect();
@@ -254,7 +254,7 @@ export class RemoteIPCPeer extends AceBaseIPCPeer {
                         super.handleMessage(msg);
                     }
                     catch (err) {
-                        this.storage.debug.error(`Failed to receive message ${msgId}:`, err);
+                        this.logger.error(`Failed to receive message ${msgId}:`, err);
                     }
                 }
                 else if (str.startsWith('{')) {
@@ -271,7 +271,7 @@ export class RemoteIPCPeer extends AceBaseIPCPeer {
     }
 
     sendMessage(message: IMessage) {
-        this.storage.debug.verbose(`[RemoteIPC] sending: `, message);
+        this.logger.trace(`[RemoteIPC] sending: `, message);
         let json = JSON.stringify(message);
         if (typeof message.to === 'string') {
             // Send to specific peer only

--- a/src/ipc/service/start.ts
+++ b/src/ipc/service/start.ts
@@ -8,11 +8,13 @@ import { type AceBaseLocalSettings } from '../../';
             switch (arg.toLowerCase()) {
                 case '--loglevel': settings.logLevel = args[i + 1] as AceBaseLocalSettings['logLevel']; break;
                 case '--maxidletime': settings.maxIdleTime = parseInt(args[i + 1]); break;
+                case '--logger': settings.loggerPluginPath = args[i + 1]; break;
             }
             return settings;
-        }, { logLevel: 'log' as AceBaseLocalSettings['logLevel'], maxIdleTime: 5000 });
+        }, { logLevel: 'log', maxIdleTime: 5000 } as { loggerPluginPath?: string, logLevel: AceBaseLocalSettings['logLevel'], maxIdleTime: number });
 
         await startServer(dbFile, {
+            loggerPluginPath: settings.loggerPluginPath,
             logLevel: settings.logLevel,
             maxIdleTime: settings.maxIdleTime,
             exit: (code) => {

--- a/src/ipc/socket.ts
+++ b/src/ipc/socket.ts
@@ -3,9 +3,9 @@ import { resolve as resolvePath } from 'path';
 import { spawn } from 'child_process';
 import { AceBaseIPCPeer, IHelloMessage, IMessage } from './ipc';
 import { Storage } from '../storage';
-import { ID, Transport } from 'acebase-core';
+import { DebugLogger, ID, Transport } from 'acebase-core';
 import { getSocketPath, MSG_DELIMITER } from './service/shared';
-// import { startServer } from './service';
+import { startServer } from './service';
 export { Server as NetIPCServer } from 'net';
 
 const masterPeerId = '[master]';
@@ -29,7 +29,7 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
 
     public server?: Server;
 
-    constructor(storage: Storage, ipcSettings: { ipcName: string; server: Server | null }) {
+    constructor(storage: Storage, ipcSettings: { ipcName: string; server: Server | null; maxIdleTime?: number; loggerPluginPath?: string }) {
 
         const isMaster = storage.settings.ipc instanceof Server;
         const peerId = isMaster ? masterPeerId : ID.generate();
@@ -55,16 +55,23 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
 
         if (!isMaster) {
             // Try starting IPC service if it is not running yet.
-            // Use maxIdleTime 0 to allow tests to remove database files when done, make this configurable!
-            const service = spawn('node', [__dirname + '/service/start.js', dbFile, '--loglevel', storage.debug.level, '--maxidletime', '0'], { detached: true, stdio: 'ignore' });
+            const args = [
+                __dirname + '/service/start.js',
+                dbFile,
+                ...(this.logger instanceof DebugLogger ? ['--loglevel', this.logger.level] : []),
+                ...(ipcSettings.loggerPluginPath ? ['--logger', ipcSettings.loggerPluginPath] : []),
+                '--maxidletime', ipcSettings.maxIdleTime?.toString() ?? '0', // Use maxIdleTime 0 to allow tests to remove database files when done
+            ];
+            const service = spawn('node', args, { detached: true, stdio: 'ignore' });
             service.unref(); // Process is detached and allowed to keep running after we exit. Do not keep a reference to it, possibly preventing app exit.
 
-            // For testing:
+            // // For testing:
             // startServer(dbFile, {
             //     maxIdleTime: 0,
-            //     logLevel: storage.debug.level,
+            //     ...(this.logger instanceof DebugLogger && { logLevel: this.logger.level }),
+            //     ...(ipcSettings.loggerPluginPath && { loggerPluginPath: ipcSettings.loggerPluginPath }),
             //     exit: (code) => {
-            //         storage.debug.log(`[IPC ${ipcSettings.ipcName}] service exited with code ${code}`);
+            //         this.logger.info(`[IPC ${ipcSettings.ipcName}] service exited with code ${code}`);
             //     },
             // });
         }
@@ -127,13 +134,13 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
 
                         try {
                             const json = message.toString('utf-8');
-                            // storage.debug.log(`[IPC ${ipcSettings.ipcName}] Received socket message: `, json);
+                            // this.logger.debug(`[IPC ${ipcSettings.ipcName}] Received socket message: `, json);
                             const serialized = JSON.parse(json);
                             const msg = Transport.deserialize2(serialized);
                             handleMessage(socket, msg);
                         }
                         catch (err) {
-                            storage.debug.error(`[IPC ${ipcSettings.ipcName}] Error parsing message: ${err}`);
+                            this.logger.error(`[IPC ${ipcSettings.ipcName}] Error parsing message: ${err}`);
                         }
                     }
                 });
@@ -163,7 +170,7 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
                             s.once('error', reject).unref();
                             s.once('connect', resolve).unref();
                         });
-                        storage.debug.log(`[IPC ${ipcSettings.ipcName}] peer ${this.id} successfully established connection to the service`);
+                        this.logger.info(`[IPC ${ipcSettings.ipcName}] peer ${this.id} successfully established connection to the service`);
                         socket = s;
                         connected = true;
                     }
@@ -173,7 +180,7 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
                             await new Promise(resolve => setTimeout(resolve, 100));
                             return tryConnect(tries + 1);
                         }
-                        storage.debug.error(`[IPC ${ipcSettings.ipcName}] peer ${this.id} cannot connect to service: ${err.message}`);
+                        this.logger.error(`[IPC ${ipcSettings.ipcName}] peer ${this.id} cannot connect to service: ${err.message}`);
                         throw err;
                     }
                 };
@@ -185,7 +192,7 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
 
                 bindEventHandler(socket, 'close', (hadError) => {
                     // Connection to server closed
-                    storage.debug.log(`IPC peer ${this.id} lost its connection to the service${hadError ? ' because of an error' : ''}`);
+                    this.logger.info(`IPC peer ${this.id} lost its connection to the service${hadError ? ' because of an error' : ''}`);
                 });
 
                 let buffer = Buffer.alloc(0); // Buffer to store incomplete messages
@@ -205,13 +212,13 @@ export class IPCSocketPeer extends AceBaseIPCPeer {
 
                         try {
                             const json = message.toString('utf-8');
-                            // storage.debug.log(`Received server message: `, json);
+                            // this.logger.debug(`Received server message: `, json);
                             const serialized = JSON.parse(json);
                             const msg = Transport.deserialize2(serialized);
                             handleMessage(socket, msg);
                         }
                         catch (err) {
-                            storage.debug.error(`Error parsing message: ${err}`);
+                            this.logger.error(`Error parsing message: ${err}`);
                         }
                     }
                 });

--- a/src/storage/context.ts
+++ b/src/storage/context.ts
@@ -1,11 +1,11 @@
-import { DebugLogger } from 'acebase-core';
-import { Storage } from '.';
-import { DataIndex } from '../data-index';
-import { AceBaseIPCPeer } from '../ipc/ipc';
+import type { LoggerPlugin } from 'acebase-core';
+import type { Storage } from '.';
+import type { DataIndex } from '../data-index';
+import type { AceBaseIPCPeer } from '../ipc/ipc';
 
 export interface IndexesContext {
     storage: Storage,
-    debug: DebugLogger,
+    logger: LoggerPlugin,
     ipc: AceBaseIPCPeer,
     indexes: DataIndex[],
 }

--- a/src/storage/create-index.ts
+++ b/src/storage/create-index.ts
@@ -61,7 +61,7 @@ export async function createIndex(
         throw new Error('Indexes are not supported in current environment because it requires Node.js fs');
     }
     // path = path.replace(/\/\*$/, ""); // Remove optional trailing "/*"
-    const { ipc, debug, indexes, storage } = context;
+    const { ipc, logger, indexes, storage } = context;
 
     const rebuild = options && options.rebuild === true;
     const indexType = (options && options.type) || 'normal';
@@ -79,7 +79,7 @@ export async function createIndex(
     }
 
     if (existingIndex && rebuild !== true) {
-        debug.log(`Index on "/${path}/*/${key}" already exists`.colorize(ColorStyle.inverse));
+        logger.info(`Index on "/${path}/*/${key}" already exists`.colorize(ColorStyle.inverse));
         return existingIndex;
     }
 
@@ -115,7 +115,7 @@ export async function createIndex(
         await index.build();
     }
     catch(err) {
-        context.debug.error(`Index build on "/${path}/*/${key}" failed: ${err.message} (code: ${err.code})`.colorize(ColorStyle.red));
+        context.logger.error(`Index build on "/${path}/*/${key}" failed: ${err.message} (code: ${err.code})`.colorize(ColorStyle.red));
         if (!existingIndex) {
             // Only remove index if we added it. Build may have failed because someone tried creating the index more than once, or rebuilding it while it was building...
             indexes.splice(indexes.indexOf(index), 1);

--- a/src/storage/custom/index.ts
+++ b/src/storage/custom/index.ts
@@ -304,11 +304,11 @@ export class CustomStorage extends Storage {
     }
 
     private async _init() {
-        this.debug.log(`Database "${this.name}" details:`.colorize(ColorStyle.dim));
-        this.debug.log(`- Type: CustomStorage`.colorize(ColorStyle.dim));
-        this.debug.log(`- Path: ${this.settings.path}`.colorize(ColorStyle.dim));
-        this.debug.log(`- Max inline value size: ${this.settings.maxInlineValueSize}`.colorize(ColorStyle.dim));
-        this.debug.log(`- Autoremove undefined props: ${this.settings.removeVoidProperties}`.colorize(ColorStyle.dim));
+        this.logger.info(`Database "${this.name}" details:`.colorize(ColorStyle.dim));
+        this.logger.info(`- Type: CustomStorage`.colorize(ColorStyle.dim));
+        this.logger.info(`- Path: ${this.settings.path}`.colorize(ColorStyle.dim));
+        this.logger.info(`- Max inline value size: ${this.settings.maxInlineValueSize}`.colorize(ColorStyle.dim));
+        this.logger.info(`- Autoremove undefined props: ${this.settings.removeVoidProperties}`.colorize(ColorStyle.dim));
 
         // Create root node if it's not there yet
         await this._customImplementation.ready();
@@ -632,7 +632,7 @@ export class CustomStorage extends Storage {
         const isArray = mainNode.type === VALUE_TYPES.ARRAY;
         if (currentRow) {
             // update
-            this.debug.log(`Node "/${path}" is being ${options.merge ? 'updated' : 'overwritten'}`.colorize(ColorStyle.cyan));
+            this.logger.info(`Node "/${path}" is being ${options.merge ? 'updated' : 'overwritten'}`.colorize(ColorStyle.cyan));
 
             // If existing is an array or object, we have to find out which children are affected
             if (currentIsObjectOrArray || newIsObjectOrArray) {
@@ -745,7 +745,7 @@ export class CustomStorage extends Storage {
         else {
             // Current node does not exist, create it and any child nodes
             // write all child nodes that must be stored in their own record
-            this.debug.log(`Node "/${path}" is being created`.colorize(ColorStyle.cyan));
+            this.logger.info(`Node "/${path}" is being created`.colorize(ColorStyle.cyan));
 
             if (isArray) {
                 // Check if the array is "intact" (all entries have an index from 0 to the end with no gaps)
@@ -786,7 +786,7 @@ export class CustomStorage extends Storage {
      */
     private async _deleteNode(path: string, options: { transaction: CustomStorageTransaction }) {
         const pathInfo = PathInfo.get(path);
-        this.debug.log(`Node "/${path}" is being deleted`.colorize(ColorStyle.cyan));
+        this.logger.info(`Node "/${path}" is being deleted`.colorize(ColorStyle.cyan));
 
         const deletePaths = [path];
         let checkExecuted = false;
@@ -808,7 +808,7 @@ export class CustomStorage extends Storage {
         const transaction = options.transaction;
         await transaction.descendantsOf(path, { metadata: false, value: false }, includeDescendantCheck, addDescendant);
 
-        this.debug.log(`Nodes ${deletePaths.map(p => `"/${p}"`).join(',')} are being deleted`.colorize(ColorStyle.cyan));
+        this.logger.info(`Nodes ${deletePaths.map(p => `"/${p}"`).join(',')} are being deleted`.colorize(ColorStyle.cyan));
         return transaction.removeMultiple(deletePaths);
     }
 
@@ -1091,7 +1091,7 @@ export class CustomStorage extends Storage {
 
                 await transaction.descendantsOf(path, { metadata: true, value: true }, includeDescendantCheck, addDescendant);
 
-                this.debug.log(`Read node "/${path}" and ${filtered ? '(filtered) ' : ''}descendants from ${descRows.length + 1} records`.colorize(ColorStyle.magenta));
+                this.logger.info(`Read node "/${path}" and ${filtered ? '(filtered) ' : ''}descendants from ${descRows.length + 1} records`.colorize(ColorStyle.magenta));
 
                 const result = targetNode;
 
@@ -1143,7 +1143,7 @@ export class CustomStorage extends Storage {
                                 const mergePossible = typeof parent[key] === typeof nodeValue && [VALUE_TYPES.OBJECT, VALUE_TYPES.ARRAY].includes(nodeType);
                                 if (!mergePossible) {
                                     // Ignore the value in the child record, see issue #20: "Assertion failed: Merging child values can only be done if existing and current values are both an array or object"
-                                    this.debug.error(`The value stored in node "${otherNode.path}" cannot be merged with the parent node, value will be ignored. This error should disappear once the target node value is updated. See issue #20 for more information`, { path, parent, key, nodeType, nodeValue });
+                                    this.logger.error(`The value stored in node "${otherNode.path}" cannot be merged with the parent node, value will be ignored. This error should disappear once the target node value is updated. See issue #20 for more information`, { path, parent, key, nodeType, nodeValue });
                                 }
                                 else {
                                     Object.keys(nodeValue).forEach(childKey => {

--- a/src/storage/mssql/index.ts
+++ b/src/storage/mssql/index.ts
@@ -300,18 +300,18 @@ export class MSSQLStorage extends Storage {
             // Get root record info
             this.rootRecord = await this.getNodeInfo('');
 
-            this.debug.log(`Database "${this.name}" details:`.colorize(ColorStyle.dim));
-            this.debug.log(`- Type: MSSQL`.colorize(ColorStyle.dim));
-            this.debug.log(`- Server: ${this.settings.server}:${this.settings.port}`.colorize(ColorStyle.dim));
-            this.debug.log(`- Database: ${this.settings.database}`.colorize(ColorStyle.dim));
-            this.debug.log(`- Max inline value size: ${this.settings.maxInlineValueSize}`.colorize(ColorStyle.dim));
+            this.logger.info(`Database "${this.name}" details:`.colorize(ColorStyle.dim));
+            this.logger.info(`- Type: MSSQL`.colorize(ColorStyle.dim));
+            this.logger.info(`- Server: ${this.settings.server}:${this.settings.port}`.colorize(ColorStyle.dim));
+            this.logger.info(`- Database: ${this.settings.database}`.colorize(ColorStyle.dim));
+            this.logger.info(`- Max inline value size: ${this.settings.maxInlineValueSize}`.colorize(ColorStyle.dim));
 
             // Load indexes
             await this.indexes.load();
             this.emit('ready');
         }
         catch (err) {
-            this.debug.error(`Error initializing MSSQL database: ${err.message}`);
+            this.logger.error(`Error initializing MSSQL database: ${err.message}`);
             this.emit('error', err);
         }
     }
@@ -637,7 +637,7 @@ export class MSSQLStorage extends Storage {
         // Insert or update node
         if (currentRow) {
             // update
-            this.debug.log(`Node "/${path}" is being ${options.merge ? 'updated' : 'overwritten'}`.colorize(ColorStyle.cyan));
+            this.logger.info(`Node "/${path}" is being ${options.merge ? 'updated' : 'overwritten'}`.colorize(ColorStyle.cyan));
 
             const updateMainNode = () => {
                 const sql = `UPDATE nodes SET type = @type, text_value = @text_value, binary_value = @binary_value, json_value = @json_value, modified = @modified, revision_nr = revision_nr + 1, revision = @revision
@@ -720,7 +720,7 @@ export class MSSQLStorage extends Storage {
         else {
             // Current node does not exist, create it and any child nodes
             // write all child nodes that must be stored in their own record
-            this.debug.log(`Node "/${path}" is being created`.colorize(ColorStyle.cyan));
+            this.logger.info(`Node "/${path}" is being created`.colorize(ColorStyle.cyan));
 
             const childCreatePromises = Object.keys(childNodeValues).map(key => {
                 const childPath = PathInfo.getChildPath(path, key);
@@ -957,7 +957,7 @@ export class MSSQLStorage extends Storage {
                 return result;
             }
 
-            this.debug.log(`Read node "/${path}" and ${filtered ? '(filtered) ' : ''}children from ${rows.length} records`.colorize(ColorStyle.magenta));
+            this.logger.info(`Read node "/${path}" and ${filtered ? '(filtered) ' : ''}children from ${rows.length} records`.colorize(ColorStyle.magenta));
 
             const targetPathKeys = PathInfo.getPathKeys(path);
             const targetRow = rows.find(row => row.path === path);

--- a/src/storage/sqlite/index.ts
+++ b/src/storage/sqlite/index.ts
@@ -317,9 +317,9 @@ export class SQLiteStorage extends Storage {
             // Get root record info
             this.rootRecord = await this.getNodeInfo('');
 
-            this.debug.log(`Database "${this.name}" details:`.colorize(ColorStyle.dim));
-            this.debug.log(`- Type: SQLite`.colorize(ColorStyle.dim));
-            this.debug.log(`- Max inline value size: ${this.settings.maxInlineValueSize}`.colorize(ColorStyle.dim));
+            this.logger.info(`Database "${this.name}" details:`.colorize(ColorStyle.dim));
+            this.logger.info(`- Type: SQLite`.colorize(ColorStyle.dim));
+            this.logger.info(`- Max inline value size: ${this.settings.maxInlineValueSize}`.colorize(ColorStyle.dim));
 
             // Load indexes
             await this.indexes.load();
@@ -523,7 +523,7 @@ export class SQLiteStorage extends Storage {
         // Insert or update node
         if (currentRow) {
             // update
-            this.debug.log(`Node "/${path}" is being ${options.merge ? 'updated' : 'overwritten'}`.colorize(ColorStyle.cyan));
+            this.logger.info(`Node "/${path}" is being ${options.merge ? 'updated' : 'overwritten'}`.colorize(ColorStyle.cyan));
 
             const updateMainNode = () => {
                 const sql = `UPDATE nodes SET type = $type, text_value = $text_value, binary_value = $binary_value, json_value = $json_value, modified = $modified, revision_nr = revision_nr + 1, revision = $revision
@@ -630,7 +630,7 @@ export class SQLiteStorage extends Storage {
         else {
             // Current node does not exist, create it and any child nodes
             // write all child nodes that must be stored in their own record
-            this.debug.log(`Node "/${path}" is being created`.colorize(ColorStyle.cyan));
+            this.logger.info(`Node "/${path}" is being created`.colorize(ColorStyle.cyan));
 
             const childCreatePromises = Object.keys(childNodeValues).map(async key => {
                 const childPath = PathInfo.getChildPath(path, key);
@@ -877,7 +877,7 @@ export class SQLiteStorage extends Storage {
                 return result;
             }
 
-            this.debug.log(`Read node "/${path}" and ${filtered ? '(filtered) ' : ''}children from ${childRows.length} records`.colorize(ColorStyle.magenta));
+            this.logger.info(`Read node "/${path}" and ${filtered ? '(filtered) ' : ''}children from ${childRows.length} records`.colorize(ColorStyle.magenta));
 
             const targetPathKeys = PathInfo.getPathKeys(path);
             const targetRow = childRows.find(row => row.path === path);

--- a/src/test/custom-logger.ts
+++ b/src/test/custom-logger.ts
@@ -1,0 +1,3 @@
+import Pino from 'pino';
+const logger = Pino({ level: 'trace' });
+export default logger;

--- a/src/test/tempdb.ts
+++ b/src/test/tempdb.ts
@@ -1,5 +1,7 @@
 import { AceBase, ID, AceBaseLocalSettings } from '..';
 import { readdir, rm, rmdir } from 'fs/promises';
+// import { resolve as resolvePath } from 'path';
+// import customLogger from './custom-logger';
 
 export async function createTempDB(enable: { transactionLogging?: boolean; logLevel?: 'verbose'|'log'|'warn'|'error'; config?: (options: any) => void } = {}) {
     // Create temp db
@@ -11,7 +13,10 @@ export async function createTempDB(enable: { transactionLogging?: boolean; logLe
     if (typeof enable.config === 'function') {
         enable.config(options);
     }
-    options.storage.ipc = 'socket';
+    // options.storage.ipc = 'socket';
+    // options.storage.ipc = { role: 'socket', maxIdleTime: 0, loggerPluginPath: resolvePath(__dirname, 'custom-logger.js') };
+    // options.logger = customLogger;
+    // options.logColors = false;
     const db = new AceBase(dbname, options);
     await db.ready();
 


### PR DESCRIPTION
This enables replacing AceBase's default logger with a logging library such as Bunyan, Winston, Pino and any other logger supporting `trace`, `debug`, `info`, `warn`, `error` and `fatal` methods.

This also adds the methods `trace`, `debug`, `info` and `fatal` to the default built-in logger.

Also see https://github.com/appy-one/acebase-core/pull/50