### PR TITLE
Fix: handle failing announced cache lookups

### DIFF
--- a/src/node-cache.ts
+++ b/src/node-cache.ts
@@ -69,20 +69,26 @@ export class NodeCache {
         }
     }
 
-    announce(path: string) {
-        let announcement = this._announcements.get(path);
-        if (!announcement) {
-            announcement = {
-                resolve: null,
-                reject: null,
-                promise: null,
-            };
-            announcement.promise = new Promise<NodeInfo>((resolve, reject) => {
-                announcement.resolve = resolve;
-                announcement.reject = reject;
-            });
-            this._announcements.set(path, announcement);
+    rejectAnnouncement(path: string, reason: any) {
+        const announcement = this._announcements.get(path);
+        if (announcement) {
+            this._announcements.delete(path);
+            announcement.reject(reason);
         }
+    }
+
+    announce(path: string) {
+        if (this._announcements.has(path)) {
+            return;
+        }
+        let resolve!: (nodeInfo: NodeInfo) => void;
+        let reject!: (reason: any) => void;
+        const promise = new Promise<NodeInfo>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        promise.catch(() => null); // Prevent unhandled rejection if rejectAnnouncement is called before anyone awaits this
+        this._announcements.set(path, { resolve, reject, promise });
     }
 
     /**

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -3480,7 +3480,7 @@ class NodeReader {
         let data = new Uint8Array(bytesPerRecord);
 
         const bytesRead = await this.storage.readData(fileIndex, data.buffer);
-        if (bytesRead < bytesPerRecord) { throw new Error(`Not enough bytes read from file at index ${fileIndex}, expected ${bytesPerRecord} but got ${bytesRead}`); }
+        if (bytesRead < bytesPerRecord) { throw new Error(`Not enough bytes read from file at index ${fileIndex}, expected ${bytesPerRecord} but got ${bytesRead}. Affected node: ${this.address.toString()}`); }
 
         const hasKeyIndex = (data[0] & FLAG_KEY_TREE) === FLAG_KEY_TREE;
         const valueType = (data[0] & FLAG_VALUE_TYPE) as NodeValueType; // Last 4-bits of first byte of read data has value type

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -2154,6 +2154,7 @@ export class AceBaseStorage extends Storage {
         }
         catch(err) {
             this.logger.error('DEBUG THIS: getNodeInfo error', err);
+            this.nodeCache.rejectAnnouncement(path, err);
             throw err;
         }
         finally {


### PR DESCRIPTION
If a database record is being read from the wrong record address (or has otherwise been corrupted), trying to read the record header fails. Because found node record addresses are cached, a reader will always first request a node's record address from cache. A first cache miss "announces" it so others can simply await the pending lookup instead of doing multiple lookups. In case of a broken record, the lookup fails and the announcement would never be rejected (or resolved). This in turn caused granted read/write locks to become stale, printing warnings about them taking too long, only releasing the locks once they timed out (120 seconds by default), causing other reads and writes being forced to wait. This is now solved by rejecting the announcement upon record read failure.