### PR TITLE
Fix: suppress unhandled promise rejections and PromiseRejectionHandledWarning

### DIFF
--- a/src/node-cache.ts
+++ b/src/node-cache.ts
@@ -87,7 +87,8 @@ export class NodeCache {
             resolve = res;
             reject = rej;
         });
-        promise.catch(() => null); // Prevent unhandled rejection if rejectAnnouncement is called before anyone awaits this
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        promise.catch(() => {}); // Prevent unhandled rejection if rejectAnnouncement is called before anyone awaits this
         this._announcements.set(path, { resolve, reject, promise });
     }
 

--- a/src/storage/binary/index.ts
+++ b/src/storage/binary/index.ts
@@ -2681,6 +2681,8 @@ class NodeReader {
                             childLock.release();
                             return { path: child.path, allocation: childAllocation };
                         });
+                    // eslint-disable-next-line @typescript-eslint/no-empty-function
+                    promise.catch(() => {}); // Suppress unhandled rejection until Promise.all attaches a handler (async gap between chunk reads)
                     childPromises.push(promise);
                 }
             });
@@ -2889,6 +2891,8 @@ class NodeReader {
                             }
                             if (child.address) {
                                 const childValuePromise = loadChildValue(child);
+                                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                                childValuePromise.catch(() => {}); // Suppress unhandled rejection until Promise.all attaches a handler (async gap between chunk reads)
                                 promises.push(childValuePromise);
                             }
                             else if (typeof child.value !== 'undefined') {


### PR DESCRIPTION
This fixes Node.js logging lines such as: "(node:211543) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: xxxxx)" because `catch` handlers have been added too late to notice. These errors occur on transactions that run too long, canceling read/write locks on child nodes (causing the rejections).